### PR TITLE
prevent invalid START_CONTRACT functionName placement

### DIFF
--- a/plugins/grace/skills/grace/grace-explainer/references/contract-driven-dev.md
+++ b/plugins/grace/skills/grace/grace-explainer/references/contract-driven-dev.md
@@ -29,7 +29,7 @@ Important distinction:
 
 ## Function Contracts
 
-Every exported function or component must have:
+Every exported function or component must have a contract placed before function signature and docstrings/comments:
 
 ```
 // START_CONTRACT: functionName

--- a/plugins/grace/skills/grace/grace-explainer/references/semantic-markup.md
+++ b/plugins/grace/skills/grace/grace-explainer/references/semantic-markup.md
@@ -48,7 +48,7 @@ Shared-docs boundary rule:
 
 ## Function or Component Level
 
-Every exported function or component must have a contract:
+Every exported function or component must have a contract placed before function signature and docstrings/comments:
 
 ```
 // START_CONTRACT: functionName

--- a/plugins/grace/skills/grace/grace-init/assets/AGENTS.md.template
+++ b/plugins/grace/skills/grace/grace-init/assets/AGENTS.md.template
@@ -53,6 +53,7 @@ Agents have freedom in HOW to implement, but not in WHAT to build. Contracts, pl
 ```
 
 ### Function or Component Level
+Function contracts must be placed above function signature and docstrings/comments. Never place `START_CONTRACT`/`END_CONTRACT` inside function bodies.
 ```
 // START_CONTRACT: functionName
 //   PURPOSE: [What it does]

--- a/plugins/grace/skills/grace/grace-setup-subagents/references/roles/module-implementer.md
+++ b/plugins/grace/skills/grace/grace-setup-subagents/references/roles/module-implementer.md
@@ -19,6 +19,7 @@ Before starting:
 While implementing:
 - Preserve MODULE_CONTRACT, MODULE_MAP, CHANGE_SUMMARY, function contracts, and semantic blocks
 - Implement exactly what the module contract requires
+- Place function contracts above both: function signature and docstrings/comments; never place START_CONTRACT/END_CONTRACT inside function body
 - Keep imports aligned with `DEPENDS`
 - Add or update module-local tests only
 - Keep logs traceable to `[Module][function][BLOCK_NAME]` where relevant

--- a/skills/grace/grace-execute/SKILL.md
+++ b/skills/grace/grace-execute/SKILL.md
@@ -66,6 +66,7 @@ For each approved step, process exactly one module at a time.
 Follow this protocol for the assigned module:
 - use the step packet as the primary source of truth
 - generate or update code with MODULE_CONTRACT, MODULE_MAP, CHANGE_SUMMARY, function contracts, and semantic blocks
+- place function contracts above both: function signature and docstrings/comments; never place START_CONTRACT/END_CONTRACT inside function body
 - generate or update module-local tests inside the approved write scope
 - preserve or add stable log markers for the required critical branches
 - keep changes inside the approved write scope

--- a/skills/grace/grace-explainer/references/contract-driven-dev.md
+++ b/skills/grace/grace-explainer/references/contract-driven-dev.md
@@ -29,7 +29,7 @@ Important distinction:
 
 ## Function Contracts
 
-Every exported function or component must have:
+Every exported function or component must have a contract placed before function signature and docstrings/comments:
 
 ```
 // START_CONTRACT: functionName

--- a/skills/grace/grace-explainer/references/semantic-markup.md
+++ b/skills/grace/grace-explainer/references/semantic-markup.md
@@ -48,7 +48,7 @@ Shared-docs boundary rule:
 
 ## Function or Component Level
 
-Every exported function or component must have a contract:
+Every exported function or component must have a contract placed before function signature and docstrings/comments:
 
 ```
 // START_CONTRACT: functionName

--- a/skills/grace/grace-init/assets/AGENTS.md.template
+++ b/skills/grace/grace-init/assets/AGENTS.md.template
@@ -53,6 +53,7 @@ Agents have freedom in HOW to implement, but not in WHAT to build. Contracts, pl
 ```
 
 ### Function or Component Level
+Function contracts must be placed above function signature and docstrings/comments. Never place `START_CONTRACT`/`END_CONTRACT` inside function bodies.
 ```
 // START_CONTRACT: functionName
 //   PURPOSE: [What it does]

--- a/skills/grace/grace-multiagent-execute/SKILL.md
+++ b/skills/grace/grace-multiagent-execute/SKILL.md
@@ -109,6 +109,7 @@ For each approved wave:
 3. Require the worker to:
    - generate or update code using the module contract and verification excerpt from the packet
    - preserve MODULE_CONTRACT, MODULE_MAP, CHANGE_SUMMARY, function contracts, and semantic blocks
+   - place function contracts above both: function signature and docstrings/comments; never place START_CONTRACT/END_CONTRACT inside function body
    - add or update module-local tests only
      - preserve or add required stable log markers for critical branches
      - run module-local verification only

--- a/skills/grace/grace-setup-subagents/references/roles/module-implementer.md
+++ b/skills/grace/grace-setup-subagents/references/roles/module-implementer.md
@@ -19,6 +19,7 @@ Before starting:
 While implementing:
 - Preserve MODULE_CONTRACT, MODULE_MAP, CHANGE_SUMMARY, function contracts, and semantic blocks
 - Implement exactly what the module contract requires
+- Place function contracts above both: function signature and docstrings/comments; never place START_CONTRACT/END_CONTRACT inside function body
 - Keep imports aligned with `DEPENDS`
 - Add or update module-local tests only
 - Keep logs traceable to `[Module][function][BLOCK_NAME]` where relevant


### PR DESCRIPTION
it is important that START_CONTRACT must be placed above function signature and function comments

ideal way to have
```
// START_FUNCTION_FunctionName
// START_CONTRACT:
// PURPOSE: Returns parsed Field as Result objects.
// INPUTS: None (uses d.Field field)
// OUTPUTS:
// - []Result - Parsed d.Field values
// - error - Error if fails to parse
// END_CONTRACT

// FunctionName parses and returns the Field as Result objects.
func (d AclRules) FunctionName() ([]Result, error) {
        // body
}

// END_FUNCTION_FunctionName
```

but now it generates START_CONTRACT inside body 