### PR TITLE
fix: credit constant-referenced markers and resolve nested block extraction

### DIFF
--- a/src/grace-lint.test.ts
+++ b/src/grace-lint.test.ts
@@ -994,6 +994,103 @@ test("run", () => {
     expect(result.issues.map((issue) => issue.code)).toContain("autonomy.required-log-marker-not-found");
   });
 
+  it("credits a required log marker referenced via a same-file constant that is actually passed to a logging call", () => {
+    const root = createProject();
+    writeCurrentDocs(root);
+
+    writeProjectFile(
+      root,
+      "src/example.ts",
+      `// START_MODULE_CONTRACT
+//   PURPOSE: Run the example flow.
+//   SCOPE: Execute the happy path.
+//   DEPENDS: none
+//   LINKS: M-EXAMPLE
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   run - Execute the example flow.
+// END_MODULE_MAP
+//
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [v0.1.0 - Added example module]
+// END_CHANGE_SUMMARY
+const marker = "[ExampleDomain][run][BLOCK_EXECUTE_FLOW]";
+
+export function run() {
+  // START_BLOCK_EXECUTE_FLOW
+  console.info(marker + " ok");
+  return "ok";
+  // END_BLOCK_EXECUTE_FLOW
+}
+`,
+    );
+
+    writeProjectFile(
+      root,
+      "src/example.test.ts",
+      `import { expect, test } from "bun:test";
+import { run } from "./example";
+
+test("run", () => {
+  expect(run()).toBe("ok");
+});
+`,
+    );
+
+    const result = lintGraceProject(root, { profile: "autonomous" });
+    expect(result.issues.map((issue) => issue.code)).not.toContain("autonomy.required-log-marker-not-found");
+  });
+
+  it("finds a required log-marker block that is nested inside a larger enclosing block", () => {
+    const root = createProject();
+    writeCurrentDocs(root);
+
+    writeProjectFile(
+      root,
+      "src/example.ts",
+      `// START_MODULE_CONTRACT
+//   PURPOSE: Run the example flow.
+//   SCOPE: Execute the happy path.
+//   DEPENDS: none
+//   LINKS: M-EXAMPLE
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   run - Execute the example flow.
+// END_MODULE_MAP
+//
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [v0.1.0 - Added example module]
+// END_CHANGE_SUMMARY
+export function run() {
+  // START_BLOCK_APPLY_STATE
+  console.info("[ExampleDomain][run][BLOCK_APPLY_STATE] ok");
+  // START_BLOCK_EXECUTE_FLOW
+  console.info("[ExampleDomain][run][BLOCK_EXECUTE_FLOW] ok");
+  // END_BLOCK_EXECUTE_FLOW
+  return "ok";
+  // END_BLOCK_APPLY_STATE
+}
+`,
+    );
+
+    writeProjectFile(
+      root,
+      "src/example.test.ts",
+      `import { expect, test } from "bun:test";
+import { run } from "./example";
+
+test("run", () => {
+  expect(run()).toBe("ok");
+});
+`,
+    );
+
+    const result = lintGraceProject(root, { profile: "autonomous" });
+    expect(result.issues.map((issue) => issue.code)).not.toContain("autonomy.required-log-marker-block-not-found");
+  });
+
   it("explains lint issue codes through the CLI", () => {
     const guide = getLintIssueGuide("docs.missing-required-artifact");
     const explanation = formatLintExplanation("docs.missing-required-artifact");

--- a/src/grace-query.test.ts
+++ b/src/grace-query.test.ts
@@ -304,6 +304,119 @@ describe("grace query core", () => {
     expect(dbHealth.nextAction).toContain("$grace-verification");
   });
 
+  it("credits a required log marker in module health when it is referenced via a same-file constant", () => {
+    const root = createProject();
+
+    writeProjectFile(
+      root,
+      "docs/knowledge-graph.xml",
+      `<KnowledgeGraph>
+  <Project NAME="Example" VERSION="0.1.0">
+    <M-EXAMPLE NAME="Example" TYPE="CORE_LOGIC">
+      <purpose>Run the example flow.</purpose>
+      <path>src/example.ts</path>
+      <depends>none</depends>
+      <verification-ref>V-M-EXAMPLE</verification-ref>
+      <annotations>
+        <fn-run PURPOSE="Run the example flow" />
+      </annotations>
+    </M-EXAMPLE>
+  </Project>
+</KnowledgeGraph>`,
+    );
+
+    writeProjectFile(
+      root,
+      "docs/development-plan.xml",
+      `<DevelopmentPlan VERSION="0.1.0">
+  <Modules>
+    <M-EXAMPLE NAME="Example" TYPE="CORE_LOGIC" STATUS="planned">
+      <contract>
+        <purpose>Run the example flow.</purpose>
+      </contract>
+      <verification-ref>V-M-EXAMPLE</verification-ref>
+    </M-EXAMPLE>
+  </Modules>
+  <ImplementationOrder>
+    <Phase-1 name="Foundation" status="pending">
+      <step-1 module="M-EXAMPLE" status="pending" verification="V-M-EXAMPLE">Implement example.</step-1>
+    </Phase-1>
+  </ImplementationOrder>
+</DevelopmentPlan>`,
+    );
+
+    writeProjectFile(
+      root,
+      "docs/verification-plan.xml",
+      `<VerificationPlan VERSION="0.1.0">
+  <ModuleVerification>
+    <V-M-EXAMPLE MODULE="M-EXAMPLE">
+      <test-files>
+        <file-1>src/example.test.ts</file-1>
+      </test-files>
+      <module-checks>
+        <command-1>bun test src/example.test.ts</command-1>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">Primary success path returns ok.</scenario-1>
+      </scenarios>
+      <required-log-markers>
+        <marker-1>[ExampleDomain][run][BLOCK_EXECUTE_FLOW]</marker-1>
+      </required-log-markers>
+      <wave-follow-up>Run the merged example integration path.</wave-follow-up>
+      <phase-follow-up>Run the full regression suite before phase completion.</phase-follow-up>
+    </V-M-EXAMPLE>
+  </ModuleVerification>
+</VerificationPlan>`,
+    );
+
+    writeProjectFile(
+      root,
+      "src/example.ts",
+      `// START_MODULE_CONTRACT
+//   PURPOSE: Run the example flow.
+//   SCOPE: Execute the happy path.
+//   DEPENDS: none
+//   LINKS: M-EXAMPLE
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   run - Execute the example flow.
+// END_MODULE_MAP
+//
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [v0.1.0 - Added example module]
+// END_CHANGE_SUMMARY
+const marker = "[ExampleDomain][run][BLOCK_EXECUTE_FLOW]";
+
+export function run() {
+  // START_BLOCK_EXECUTE_FLOW
+  console.info(marker + " ok");
+  return "ok";
+  // END_BLOCK_EXECUTE_FLOW
+}
+`,
+    );
+
+    writeProjectFile(
+      root,
+      "src/example.test.ts",
+      `import { expect, test } from "bun:test";
+import { run } from "./example";
+
+test("run", () => {
+  expect(run()).toBe("ok");
+});
+`,
+    );
+
+    const index = loadGraceArtifactIndex(root);
+    const health = buildModuleHealth(index, resolveModule(index, "M-EXAMPLE"));
+    const issueCodes = [...health.blockers, ...health.warnings].map((issue) => issue.code);
+    expect(issueCodes).not.toContain("health.required-log-marker-not-found");
+    expect(issueCodes).not.toContain("health.required-log-marker-block-not-found");
+  });
+
   it("preserves ambiguity errors when resolving verification entries", () => {
     const root = createQueryProject();
     writeProjectFile(

--- a/src/lint/core.ts
+++ b/src/lint/core.ts
@@ -10,8 +10,10 @@ import {
   collectCodeFiles,
   findSection,
   hasGraceMarkers,
+  hasRuntimeMarkerEvidence,
   lineNumberAt,
   normalizeRelative,
+  parseMarkerBlockName,
   readTextIfExists,
   stripCommentPrefix,
 } from "../project-utils";
@@ -610,42 +612,6 @@ function lintAutonomousReadiness(
   ignoredDirs: string[],
 ) {
   const isLikelyTestPath = (relativePath: string) => /(^|\/)(__tests__|tests)(\/|$)|(^|\/)(test_[^/]+|[^/]+\.(test|spec)\.[^.]+)$/.test(relativePath);
-  const looksLikeEvidenceEmission = (line: string) => /(console\.|logger\.|tracer\.|trace\(|emit\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
-  const isEvidenceLine = (line: string) => !/^\s*(\/\/|#|--|;+|\*)/.test(line) && looksLikeEvidenceEmission(line);
-  const parseMarkerBlockName = (marker: string) => {
-    const match = marker.match(/\[([^\]]+)\]\s*$/);
-    if (!match) {
-      return undefined;
-    }
-
-    return match[1].startsWith("BLOCK_") ? match[1].slice("BLOCK_".length) : undefined;
-  };
-  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Finds a same-file identifier assigned exactly the marker string (e.g. `static let x = "[Module][fn][BLOCK_X]"`
-  // or `const x = "..."`), so a marker interpolated into a log call via that identifier can still be credited as
-  // real runtime evidence — not just markers repeated as a literal at the call site.
-  const findConstantNameForMarker = (text: string, marker: string) => {
-    const pattern = new RegExp(
-      `([A-Za-z_$][A-Za-z0-9_$]*)\\s*(?::\\s*[^=\\n]+)?(?<![=!<>])=(?!=)\\s*(['"\`])${escapeRegExp(marker)}\\2`,
-    );
-    return text.match(pattern)?.[1];
-  };
-  const lineHasRuntimeMarker = (text: string, marker: string) => {
-    const lines = text.split("\n");
-    if (lines.some((line) => line.includes(marker) && isEvidenceLine(line))) {
-      return true;
-    }
-
-    // Fall back to a same-file constant that is genuinely referenced from an emission-shaped line — this is
-    // what lets `log.info("\(markerConstant) ...")`-style call sites count, without crediting a constant that
-    // is merely declared (or returned/compared) but never actually passed to anything log-shaped.
-    const constantName = findConstantNameForMarker(text, marker);
-    if (!constantName) {
-      return false;
-    }
-    const nameBoundary = new RegExp(`\\b${escapeRegExp(constantName)}\\b`);
-    return lines.some((line) => nameBoundary.test(line) && isEvidenceLine(line));
-  };
 
   if (!operationalPackets) {
     addAutonomyIssue(
@@ -873,7 +839,7 @@ function lintAutonomousReadiness(
           })
         : implementationFiles;
 
-      if (!scopedImplementationFiles.some((file) => lineHasRuntimeMarker(file.text, marker))) {
+      if (!scopedImplementationFiles.some((file) => hasRuntimeMarkerEvidence(file.text, marker))) {
         addAutonomyIssue(
           result,
           "error",

--- a/src/lint/core.ts
+++ b/src/lint/core.ts
@@ -611,6 +611,7 @@ function lintAutonomousReadiness(
 ) {
   const isLikelyTestPath = (relativePath: string) => /(^|\/)(__tests__|tests)(\/|$)|(^|\/)(test_[^/]+|[^/]+\.(test|spec)\.[^.]+)$/.test(relativePath);
   const looksLikeEvidenceEmission = (line: string) => /(console\.|logger\.|tracer\.|trace\(|emit\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
+  const isEvidenceLine = (line: string) => !/^\s*(\/\/|#|--|;+|\*)/.test(line) && looksLikeEvidenceEmission(line);
   const parseMarkerBlockName = (marker: string) => {
     const match = marker.match(/\[([^\]]+)\]\s*$/);
     if (!match) {
@@ -619,10 +620,32 @@ function lintAutonomousReadiness(
 
     return match[1].startsWith("BLOCK_") ? match[1].slice("BLOCK_".length) : undefined;
   };
-  const lineHasRuntimeMarker = (text: string, marker: string) =>
-    text
-      .split("\n")
-      .some((line) => line.includes(marker) && !/^\s*(\/\/|#|--|;+|\*)/.test(line) && looksLikeEvidenceEmission(line));
+  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Finds a same-file identifier assigned exactly the marker string (e.g. `static let x = "[Module][fn][BLOCK_X]"`
+  // or `const x = "..."`), so a marker interpolated into a log call via that identifier can still be credited as
+  // real runtime evidence — not just markers repeated as a literal at the call site.
+  const findConstantNameForMarker = (text: string, marker: string) => {
+    const pattern = new RegExp(
+      `([A-Za-z_$][A-Za-z0-9_$]*)\\s*(?::\\s*[^=\\n]+)?(?<![=!<>])=(?!=)\\s*(['"\`])${escapeRegExp(marker)}\\2`,
+    );
+    return text.match(pattern)?.[1];
+  };
+  const lineHasRuntimeMarker = (text: string, marker: string) => {
+    const lines = text.split("\n");
+    if (lines.some((line) => line.includes(marker) && isEvidenceLine(line))) {
+      return true;
+    }
+
+    // Fall back to a same-file constant that is genuinely referenced from an emission-shaped line — this is
+    // what lets `log.info("\(markerConstant) ...")`-style call sites count, without crediting a constant that
+    // is merely declared (or returned/compared) but never actually passed to anything log-shaped.
+    const constantName = findConstantNameForMarker(text, marker);
+    if (!constantName) {
+      return false;
+    }
+    const nameBoundary = new RegExp(`\\b${escapeRegExp(constantName)}\\b`);
+    return lines.some((line) => nameBoundary.test(line) && isEvidenceLine(line));
+  };
 
   if (!operationalPackets) {
     addAutonomyIssue(

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -125,3 +125,51 @@ export function findSection(text: string, startMarker: string, endMarker: string
     endLine: lineNumberAt(text, endIndex),
   } satisfies TextSection;
 }
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function looksLikeEvidenceEmission(line: string) {
+  return /(console\.|logger\.|tracer\.|trace\(|emit\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
+}
+
+function isEvidenceLine(line: string) {
+  return !/^\s*(\/\/|#|--|;+|\*)/.test(line) && looksLikeEvidenceEmission(line);
+}
+
+// Finds a same-file identifier assigned exactly the marker string (e.g. `static let x = "[Module][fn][BLOCK_X]"`
+// or `const x = "..."`), so a marker interpolated into a log call via that identifier can still be credited as
+// real runtime evidence -- not just markers repeated as a literal at the call site.
+function findConstantNameForMarker(text: string, marker: string) {
+  const pattern = new RegExp(
+    `([A-Za-z_$][A-Za-z0-9_$]*)\\s*(?::\\s*[^=\\n]+)?(?<![=!<>])=(?!=)\\s*(['"\`])${escapeRegExp(marker)}\\2`,
+  );
+  return text.match(pattern)?.[1];
+}
+
+// Shared by `grace lint`'s autonomy check and `grace module health`'s verification-entry check -- both decide
+// whether a required log marker has genuine runtime evidence. Previously reimplemented independently in each
+// caller, which let a fix land in one without the other; keep this as the single source of truth.
+export function hasRuntimeMarkerEvidence(text: string, marker: string): boolean {
+  const lines = text.split("\n");
+  if (lines.some((line) => line.includes(marker) && isEvidenceLine(line))) {
+    return true;
+  }
+
+  const constantName = findConstantNameForMarker(text, marker);
+  if (!constantName) {
+    return false;
+  }
+  const nameBoundary = new RegExp(`\\b${escapeRegExp(constantName)}\\b`);
+  return lines.some((line) => nameBoundary.test(line) && isEvidenceLine(line));
+}
+
+export function parseMarkerBlockName(marker: string): string | undefined {
+  const match = marker.match(/\[([^\]]+)\]\s*$/);
+  if (!match) {
+    return undefined;
+  }
+
+  return match[1].startsWith("BLOCK_") ? match[1].slice("BLOCK_".length) : undefined;
+}

--- a/src/query/core.ts
+++ b/src/query/core.ts
@@ -473,16 +473,37 @@ function parseScopedFieldSections(text: string) {
   return sections;
 }
 
-function parseBlocks(text: string) {
+function parseBlocks(text: string): FileBlockRecord[] {
+  // Stack-based, not a single backreferenced regex: a same-name backreference match (`START_BLOCK_X...END_BLOCK_\1`)
+  // stops at the first END_BLOCK_X it finds, so a block nested inside another block gets swallowed whole by its
+  // enclosing block's non-greedy match and is never extracted on its own (`matchAll`'s lastIndex only advances
+  // past the outer match). A stack mirrors `lintScopedMarkers` in lint/core.ts and correctly resolves nesting.
   const blocks: FileBlockRecord[] = [];
-  for (const match of text.matchAll(/START_BLOCK_([A-Za-z0-9_]+)([\s\S]*?)END_BLOCK_\1/g)) {
-    const startIndex = match.index ?? 0;
-    const endIndex = startIndex + match[0].length;
-    blocks.push({
-      name: match[1],
-      startLine: lineNumberAt(text, startIndex),
-      endLine: lineNumberAt(text, endIndex),
-    });
+  const lines = text.split("\n");
+  const stack: Array<{ name: string; startLine: number }> = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const startMatch = line.match(/START_BLOCK_([A-Za-z0-9_]+)/);
+    if (startMatch?.[1]) {
+      stack.push({ name: startMatch[1], startLine: index + 1 });
+    }
+
+    const endMatch = line.match(/END_BLOCK_([A-Za-z0-9_]+)/);
+    if (endMatch?.[1]) {
+      const name = endMatch[1];
+      let openIndex = -1;
+      for (let i = stack.length - 1; i >= 0; i -= 1) {
+        if (stack[i].name === name) {
+          openIndex = i;
+          break;
+        }
+      }
+      if (openIndex !== -1) {
+        const [open] = stack.splice(openIndex, 1);
+        blocks.push({ name: open.name, startLine: open.startLine, endLine: index + 1 });
+      }
+    }
   }
 
   return blocks;

--- a/src/query/health.ts
+++ b/src/query/health.ts
@@ -3,23 +3,11 @@ import path from "node:path";
 
 import { getModuleName, getModulePath, getModuleType, resolveModule } from "./core";
 import { checkModuleCheckReferences } from "../verification/check-references";
+import { hasRuntimeMarkerEvidence, parseMarkerBlockName } from "../project-utils";
 import type { GraceArtifactIndex, ModuleHealthIssue, ModuleHealthRecord, ModuleRecord } from "./types";
 
 function isLikelyTestPath(relativePath: string) {
   return /(^|\/)(__tests__|tests)(\/|$)|(^|\/)(test_[^/]+|[^/]+\.(test|spec)\.[^.]+)$/.test(relativePath);
-}
-
-function parseMarkerBlockName(marker: string) {
-  const match = marker.match(/\[([^\]]+)\]\s*$/);
-  if (!match) {
-    return undefined;
-  }
-
-  return match[1].startsWith("BLOCK_") ? match[1].slice("BLOCK_".length) : undefined;
-}
-
-function looksLikeEvidenceEmission(line: string) {
-  return /(console\.|logger\.|tracer\.|trace\(|emit\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
 }
 
 function pushIssue(
@@ -236,7 +224,7 @@ export function buildModuleHealth(index: GraceArtifactIndex, moduleRecord: Modul
     }
 
     for (const marker of entry.requiredLogMarkers) {
-      if (!runtimeTexts.some(({ text }) => text.split("\n").some((line) => line.includes(marker) && !/^\s*(\/\/|#|--|;+|\*)/.test(line) && looksLikeEvidenceEmission(line)))) {
+      if (!runtimeTexts.some(({ text }) => hasRuntimeMarkerEvidence(text, marker))) {
         pushIssue(
           blockers,
           "error",


### PR DESCRIPTION
## Summary

Two related autonomy-gate false positives, both found repeatedly while running
`grace lint --profile autonomous` against a real Swift project — correctly-emitted
log markers kept being reported as missing.

- **`hasRuntimeMarkerEvidence`** (formerly `lineHasRuntimeMarker`) required the
  literal marker text and a logging-call pattern on the *same line*. Fails when a
  marker is declared once as a named constant and interpolated into the log call
  elsewhere (e.g. `static let marker = "[...]"` then `log.info("\(marker) ...")`).
  Fixed by resolving same-file `identifier = "<marker>"` assignments and crediting
  a line that references that identifier from an emission-shaped call — while
  still requiring genuine emission evidence, so a constant that's declared but
  never logged is still correctly flagged.
- **`parseBlocks`** extracted `START_BLOCK_X...END_BLOCK_X` pairs via a single
  backreferenced regex, which swallows a block nested inside another block whole
  (the outer match's non-greedy search consumes past the inner END marker looking
  for its own). Replaced with a stack-based line scanner, mirroring the
  nesting-aware approach `lintScopedMarkers` already uses for the
  mismatched-block-end check in the same file.

**Follow-up in the second commit**: `grace module health` (`src/query/health.ts`)
turned out to have an independent, duplicated copy of the same marker-evidence
check (its own `looksLikeEvidenceEmission` + inline same-line requirement),
so the constant-reference fix didn't reach it. The nested-block fix *did*
already apply there too, since both callers read from the same `file.blocks`
data populated by `parseBlocks`. Extracted the shared logic into
`src/project-utils.ts` (`hasRuntimeMarkerEvidence`, `parseMarkerBlockName`) so
`grace lint` and `grace module health` can no longer drift apart on this again.

## Test plan

- [x] Three new regression tests added (two for `grace lint`, one for `grace
      module health`), all confirmed failing against the pre-fix code before
      each fix landed
- [x] `bun test`: 61/61 passing, 0 regressions
- [x] `bun run validate:ci` / `release:checklist`: both pass
- [x] Verified against the real motivating case: `grace lint --profile
      autonomous` on the source project dropped from 14 to 12 errors, with
      the two fixed findings gone and one legitimate (non-tool-bug) finding
      correctly still present; output unchanged after the health.ts
      de-duplication refactor, confirming behavior parity