### PR TITLE
fix(query): support constant markers and nested blocks

### DIFF
--- a/src/grace-query.test.ts
+++ b/src/grace-query.test.ts
@@ -52,23 +52,15 @@ function writeGrace4Artifacts(root: string) {
   );
 }
 
-function writeGovernedFiles(root: string) {
-  writeProjectFile(
-    root,
-    "src/db/index.ts",
-    `// START_MODULE_CONTRACT
-//   PURPOSE: Expose the shared database surface
-//   SCOPE: Provide the shared db client singleton
-//   DEPENDS: none
-//   LINKS: M-DB
-// END_MODULE_CONTRACT
-//
-// START_MODULE_MAP
-//   db - Shared database client export
-// END_MODULE_MAP
-export const db = {};
-`,
-  );
+function writeProviderRuntime(
+  root: string,
+  options: { declarations?: string; body?: string } = {},
+) {
+  const declarations = options.declarations ? `${options.declarations}\n` : "";
+  const body = options.body ?? `  console.info("[ProviderConfigPersistence][getProviderConfig][BLOCK_GET_PROVIDER_CONFIG] read");
+  // START_BLOCK_GET_PROVIDER_CONFIG
+  return { ok: true };
+  // END_BLOCK_GET_PROVIDER_CONFIG`;
   writeProjectFile(
     root,
     "src/provider/config-repo.ts",
@@ -92,11 +84,8 @@ export const db = {};
 //   PURPOSE: Read provider configuration from storage
 //   OUTPUTS: { Promise<object> }
 // END_CONTRACT: getProviderConfig
-export async function getProviderConfig() {
-  console.info("[ProviderConfigPersistence][getProviderConfig][BLOCK_GET_PROVIDER_CONFIG] read");
-  // START_BLOCK_GET_PROVIDER_CONFIG
-  return { ok: true };
-  // END_BLOCK_GET_PROVIDER_CONFIG
+${declarations}export async function getProviderConfig() {
+${body}
 }
 //
 // START_CONTRACT: providerConfigRepo
@@ -105,6 +94,26 @@ export async function getProviderConfig() {
 export const providerConfigRepo = { getProviderConfig };
 `,
   );
+}
+
+function writeGovernedFiles(root: string) {
+  writeProjectFile(
+    root,
+    "src/db/index.ts",
+    `// START_MODULE_CONTRACT
+//   PURPOSE: Expose the shared database surface
+//   SCOPE: Provide the shared db client singleton
+//   DEPENDS: none
+//   LINKS: M-DB
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   db - Shared database client export
+// END_MODULE_MAP
+export const db = {};
+`,
+  );
+  writeProviderRuntime(root);
   writeProjectFile(
     root,
     "src/provider/config-repo.test.ts",
@@ -263,6 +272,41 @@ describe("grace query core", () => {
     const dbHealth = buildModuleHealth(index, resolveModule(index, "M-DB"));
     expect(dbHealth.state).toBe("blocked");
     expect(dbHealth.blockers.map((blocker) => blocker.code)).toContain("health.verification-missing-commands");
+  });
+
+  it("credits a required marker emitted through an identifier-safe constant inside nested blocks", () => {
+    const root = createQueryProject();
+    writeProviderRuntime(root, {
+      declarations: 'const marker$ = "[ProviderConfigPersistence][getProviderConfig][BLOCK_GET_PROVIDER_CONFIG]";',
+      body: `  console.info(marker$ + " read");
+  // START_BLOCK_PROVIDER_OPERATION
+  // START_BLOCK_GET_PROVIDER_CONFIG
+  return { ok: true };
+  // END_BLOCK_GET_PROVIDER_CONFIG
+  // END_BLOCK_PROVIDER_OPERATION`,
+    });
+
+    const index = loadGraceArtifactIndex(root);
+    const health = buildModuleHealth(index, resolveModule(index, "M-PROVIDER-PERSIST"));
+    expect(health.blockers.map((blocker) => blocker.code)).not.toContain("health.required-log-marker-not-found");
+    expect(health.blockers.map((blocker) => blocker.code)).not.toContain("health.required-log-marker-block-not-found");
+  });
+
+  it("does not credit a required marker when only a longer identifier is emitted", () => {
+    const root = createQueryProject();
+    writeProviderRuntime(root, {
+      declarations: `const marker$ = "[ProviderConfigPersistence][getProviderConfig][BLOCK_GET_PROVIDER_CONFIG]";
+const marker$Other = "[ProviderConfigPersistence][getProviderConfig][other]";`,
+      body: `  console.info(marker$Other + " read");
+  // START_BLOCK_GET_PROVIDER_CONFIG
+  return { ok: true };
+  // END_BLOCK_GET_PROVIDER_CONFIG`,
+    });
+
+    const index = loadGraceArtifactIndex(root);
+    const health = buildModuleHealth(index, resolveModule(index, "M-PROVIDER-PERSIST"));
+    expect(health.blockers.map((blocker) => blocker.code)).toContain("health.required-log-marker-not-found");
+    expect(health.blockers.map((blocker) => blocker.code)).not.toContain("health.required-log-marker-block-not-found");
   });
 
   it("fails closed before returning records from invalid grammar or projections", () => {

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, test } from "bun:test";
 
-import { analyzeGovernedFile, parseGovernedFile } from "./project-utils";
+import { analyzeGovernedFile, hasRuntimeMarkerEvidence, parseGovernedFile } from "./project-utils";
 
 function contract(mapMode: "EXPORTS" | "LOCALS" | "SUMMARY" | "NONE", moduleMap = ""): string {
   return `// START_MODULE_CONTRACT
@@ -56,6 +56,48 @@ describe("governed file analysis", () => {
     expect(codes).toContain("markup.duplicate-marker");
     expect(codes).toContain("markup.missing-end-marker");
     expect(issues.filter((issue) => issue.code.startsWith("markup.")).every((issue) => typeof issue.line === "number")).toBe(true);
+  });
+
+  it("parses properly nested semantic blocks without reporting overlap", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-nested-blocks-"));
+    const file = path.join(root, "nested.ts");
+    const text = `// START_BLOCK_OUTER
+// START_BLOCK_INNER
+export const value = true;
+// END_BLOCK_INNER
+// END_BLOCK_OUTER
+`;
+
+    expect(parseGovernedFile(root, file, text).blocks).toEqual([
+      { name: "OUTER", startLine: 1, endLine: 5 },
+      { name: "INNER", startLine: 2, endLine: 4 },
+    ]);
+    expect(analyzeGovernedFile(root, file, text).issues.map((issue) => issue.code)).not.toContain("markup.overlapping-markers");
+  });
+
+  it("does not manufacture an outer block from crossed nesting", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-crossed-blocks-"));
+    const file = path.join(root, "crossed.ts");
+    const text = `// START_BLOCK_OUTER
+// START_BLOCK_INNER
+// END_BLOCK_OUTER
+// END_BLOCK_INNER
+`;
+
+    expect(parseGovernedFile(root, file, text).blocks.map((block) => block.name)).toEqual(["INNER"]);
+    const codes = analyzeGovernedFile(root, file, text).issues.map((issue) => issue.code);
+    expect(codes).toContain("markup.mismatched-marker");
+    expect(codes).toContain("markup.missing-end-marker");
+  });
+
+  it("credits exact marker constants with identifier-aware boundaries", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    expect(hasRuntimeMarkerEvidence(`console.info("${marker} ok");`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`const marker$ = "${marker}";\nconsole.info(marker$ + " ok");`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`static let marker = "${marker}"\nlog.info("\\(marker) ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`const marker$ = "${marker}";\nconsole.info(marker$Other + " ok");`, marker)).toBe(false);
+    expect(hasRuntimeMarkerEvidence(`const marker$ = "${marker}";\nreturn marker$;`, marker)).toBe(false);
+    expect(hasRuntimeMarkerEvidence(`// const marker$ = "${marker}";\nconsole.info(marker$ + " ok");`, marker)).toBe(false);
   });
 
   it("emits bounded-confidence diagnostics for heuristic Python analysis", () => {

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -123,6 +123,57 @@ export function hasGraceMarkers(text: string) {
     .some((line) => /^(\s*)(\/\/|#|--|;+|\*)\s*(START_MODULE_CONTRACT|START_MODULE_MAP|START_CONTRACT:|START_BLOCK_|START_CHANGE_SUMMARY)/.test(line));
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isCommentOnlyLine(line: string) {
+  return /^\s*(\/\/|#|--|;+|\*)/.test(line);
+}
+
+function looksLikeEvidenceEmission(line: string) {
+  return /(console\.|logger\.|tracer\.|trace\s*\(|emit\s*\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
+}
+
+/** Extracts the semantic block name encoded at the end of a required log marker. */
+export function parseMarkerBlockName(marker: string) {
+  const match = marker.match(/\[([^\]]+)\]\s*$/);
+  return match?.[1]?.startsWith("BLOCK_") ? match[1].slice("BLOCK_".length) : undefined;
+}
+
+/**
+ * Returns true when a required marker is emitted directly or through a same-file
+ * identifier assigned to that exact marker. Identifier-aware boundaries keep
+ * names such as marker$ distinct from marker$Other.
+ */
+export function hasRuntimeMarkerEvidence(text: string, marker: string) {
+  const lines = text.split("\n");
+  if (lines.some((line) => !isCommentOnlyLine(line) && line.includes(marker) && looksLikeEvidenceEmission(line))) {
+    return true;
+  }
+
+  const identifiers = new Set<string>();
+  for (const line of lines) {
+    if (isCommentOnlyLine(line)) {
+      continue;
+    }
+    for (const quote of ['"', "'", "`"]) {
+      const assignmentPattern = new RegExp(
+        `([A-Za-z_$][A-Za-z0-9_$]*)\\s*(?::[^=\\n]+)?=\\s*${escapeRegExp(`${quote}${marker}${quote}`)}`,
+        "g",
+      );
+      for (const match of line.matchAll(assignmentPattern)) {
+        identifiers.add(match[1]!);
+      }
+    }
+  }
+
+  return [...identifiers].some((identifier) => {
+    const identifierUse = new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(identifier)}(?![A-Za-z0-9_$])`);
+    return lines.some((line) => !isCommentOnlyLine(line) && looksLikeEvidenceEmission(line) && identifierUse.test(line));
+  });
+}
+
 export function collectCodeFiles(root: string, ignoredDirs: string[], currentDir = root): string[] {
   const files: string[] = [];
   const ignoredDirSet = new Set([...DEFAULT_IGNORED_DIRS, ...ignoredDirs]);
@@ -307,22 +358,26 @@ function parseScopedFieldSections(text: string): FileContractRecord[] {
 
 function parseBlocks(text: string): FileBlockRecord[] {
   const blocks: FileBlockRecord[] = [];
+  const openBlocks: Array<{ name: string; startLine: number }> = [];
   const lines = text.split("\n");
-  for (let startIndex = 0; startIndex < lines.length; startIndex += 1) {
-    const start = stripCommentPrefix(lines[startIndex]!).trim().match(/^START_BLOCK_([A-Z0-9_]+)$/);
-    if (!start) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const marker = stripCommentPrefix(lines[index]!).trim();
+    const start = marker.match(/^START_BLOCK_([A-Z0-9_]+)$/);
+    if (start?.[1]) {
+      openBlocks.push({ name: start[1], startLine: index + 1 });
       continue;
     }
-    const name = start[1]!;
-    const relativeEnd = lines.slice(startIndex + 1).findIndex((line) => stripCommentPrefix(line).trim() === `END_BLOCK_${name}`);
-    if (relativeEnd < 0) {
+
+    const end = marker.match(/^END_BLOCK_([A-Z0-9_]+)$/);
+    const open = openBlocks.at(-1);
+    if (!end?.[1] || !open || open.name !== end[1]) {
       continue;
     }
-    const endIndex = startIndex + 1 + relativeEnd;
-    blocks.push({ name, startLine: startIndex + 1, endLine: endIndex + 1 });
-    startIndex = endIndex;
+
+    openBlocks.pop();
+    blocks.push({ name: open.name, startLine: open.startLine, endLine: index + 1 });
   }
-  return blocks;
+  return blocks.sort((left, right) => left.startLine - right.startLine || left.endLine - right.endLine);
 }
 
 function splitList(text?: string): string[] {
@@ -334,7 +389,7 @@ type MarkerEvent = { direction: "start" | "end"; family: string; name: string; k
 function validateMarkerStructure(file: string, text: string): LintIssue[] {
   const issues: LintIssue[] = [];
   const completed = new Set<string>();
-  let open: MarkerEvent | null = null;
+  const openMarkers: MarkerEvent[] = [];
   const lines = text.split("\n");
   for (let index = 0; index < lines.length; index += 1) {
     const event = parseMarkerEvent(stripCommentPrefix(lines[index]!).trim(), index + 1);
@@ -342,7 +397,15 @@ function validateMarkerStructure(file: string, text: string): LintIssue[] {
       continue;
     }
     if (event.direction === "start") {
-      if (open) {
+      const open = openMarkers.at(-1);
+      if (openMarkers.some((marker) => marker.key === event.key)) {
+        if (open) {
+          issues.push(markupIssue("error", "markup.overlapping-markers", file, event.line, `${event.key} starts before ${open.key} ends.`));
+        }
+        issues.push(markupIssue("error", "markup.duplicate-marker", file, event.line, `${event.key} has a duplicate start marker.`));
+        continue;
+      }
+      if (open && !(open.family === "block" && event.family === "block")) {
         issues.push(markupIssue("error", "markup.overlapping-markers", file, event.line, `${event.key} starts before ${open.key} ends.`));
         if (open.key === event.key) {
           issues.push(markupIssue("error", "markup.duplicate-marker", file, event.line, `${event.key} has a duplicate start marker.`));
@@ -352,22 +415,22 @@ function validateMarkerStructure(file: string, text: string): LintIssue[] {
       if (completed.has(event.key)) {
         issues.push(markupIssue("error", "markup.duplicate-marker", file, event.line, `${event.key} is declared more than once.`));
       }
-      open = event;
+      openMarkers.push(event);
       continue;
     }
+    const open = openMarkers.at(-1);
     if (!open) {
       issues.push(markupIssue("error", "markup.reversed-marker", file, event.line, `${event.key} ends without a preceding matching start marker.`));
       continue;
     }
     if (open.key !== event.key) {
       issues.push(markupIssue("error", "markup.mismatched-marker", file, event.line, `${event.key} does not match open marker ${open.key}.`));
-      open = null;
       continue;
     }
     completed.add(event.key);
-    open = null;
+    openMarkers.pop();
   }
-  if (open) {
+  for (const open of openMarkers) {
     issues.push(markupIssue("error", "markup.missing-end-marker", file, open.line, `${open.key} is missing its end marker.`));
   }
   return issues;

--- a/src/query/health.ts
+++ b/src/query/health.ts
@@ -2,20 +2,12 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { getModuleImplementationFiles, getModuleName, getModulePath, getModuleType, resolveModule } from "./core";
+import { hasRuntimeMarkerEvidence, parseMarkerBlockName } from "../project-utils";
 import { checkModuleCheckReferences } from "../verification/check-references";
 import type { GraceArtifactIndex, ModuleHealthIssue, ModuleHealthRecord, ModuleRecord } from "./types";
 
 function isLikelyTestPath(relativePath: string) {
   return /(^|\/)(__tests__|tests)(\/|$)|(^|\/)(test_[^/]+|[^/]+\.(test|spec)\.[^.]+)$/.test(relativePath);
-}
-
-function parseMarkerBlockName(marker: string) {
-  const match = marker.match(/\[([^\]]+)\]\s*$/);
-  return match && match[1].startsWith("BLOCK_") ? match[1].slice("BLOCK_".length) : undefined;
-}
-
-function looksLikeEvidenceEmission(line: string) {
-  return /(console\.|logger\.|tracer\.|trace\(|emit\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
 }
 
 function pushIssue(issues: ModuleHealthIssue[], severity: ModuleHealthIssue["severity"], code: string, message: string, remediation: string) {
@@ -92,7 +84,7 @@ export function buildModuleHealth(index: GraceArtifactIndex, moduleRecord: Modul
     }
 
     for (const marker of entry.requiredLogMarkers) {
-      if (!runtimeTexts.some(({ text }) => text.split("\n").some((line) => line.includes(marker) && !/^\s*(\/\/|#|--|;+|\*)/.test(line) && looksLikeEvidenceEmission(line)))) {
+      if (!runtimeTexts.some(({ text }) => hasRuntimeMarkerEvidence(text, marker))) {
         pushIssue(blockers, "error", "health.required-log-marker-not-found", `${entry.id} requires marker ${marker}, but it was not found in linked runtime files.`, `Emit ${marker} from ${moduleRecord.id} runtime code or update the verification entry.`);
       }
       const requiredBlock = parseMarkerBlockName(marker);


### PR DESCRIPTION
Ports and completes the fixes proposed in #15 for the current GRACE 4 architecture. Module health now credits exact required markers emitted through same-file constants, uses identifier-aware boundaries for names such as marker$, and rejects longer-identifier false positives. Semantic BLOCK markers are parsed and structurally validated with proper nesting, while crossed nesting remains invalid. Includes unit and module-health regressions, including the negative boundary case requested during review.\n\nCredit to @Borodaus3000 for the original report and implementation direction in #15.