### PR TITLE
chore: prepare 4.0.1 stable release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "GRACE (Graph-RAG Anchored Code Engineering) - a methodology by Vladimir Ivanov for contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification",
-    "version": "4.0.0"
+    "version": "4.0.1"
   },
   "plugins": [
     {
       "name": "grace",
       "source": "./plugins/grace",
       "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "author": {
         "name": "osovv",
         "url": "https://github.com/osovv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## <small>4.0.1 (2026-07-26)</small>
+
+### Summary
+
+This release fixes the health query engine to correctly recognize required log markers when they are emitted through identifier-safe constants, such as template string variables or assigned variable names, within nested block structures. Previously, the marker validation could miss evidence when a marker string was stored in a variable rather than inlined, leading to false health blockers, and nested semantic blocks could be misreported as overlapping. The improved block parser now handles proper nesting without false positives and reliably credits evidence from constant-assigned marker references, making module health checks more accurate for real-world runtime code patterns.
+
+* fix(query): support constant markers and nested blocks ([7746ff6](https://github.com/osovv/grace-marketplace/commit/7746ff6))
+
 ## <small>4.0.0 (2026-07-26)</small>
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository ships the GRACE skills plus the optional `grace` CLI. It is a packaging and distribution repository, not an end-user application.
 
-Current packaged version: `4.0.0`
+Current packaged version: `4.0.1`
 
 ## What This Repository Ships
 

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,6 +1,6 @@
 name: grace
 description: "GRACE (Graph-RAG Anchored Code Engineering) - contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification"
-version: 4.0.0
+version: 4.0.1
 author: osovv
 license: MIT
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osovv/grace-cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation with a Bun-powered grace binary.",
   "license": "MIT",
   "homepage": "https://github.com/osovv/grace-marketplace#readme",

--- a/plugins/grace/.claude-plugin/plugin.json
+++ b/plugins/grace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grace",
   "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": {
     "name": "osovv",
     "url": "https://github.com/osovv"

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -11,7 +11,7 @@ import { verificationCommand } from "./grace-verification";
 const main = defineCommand({
   meta: {
     name: "grace",
-    version: "4.0.0",
+    version: "4.0.1",
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {


### PR DESCRIPTION
Prepare @osovv/grace-cli 4.0.1 for stable publication. After required checks pass and the pull request is merged, run `bun run release:finalize 4.0.1` from clean synchronized main to create and push the immutable release tag.