### PR TITLE
fix(cli): align module health parsing and summaries

### DIFF
--- a/plugins/grace/skills/grace/grace-status/SKILL.md
+++ b/plugins/grace/skills/grace/grace-status/SKILL.md
@@ -4,7 +4,7 @@ description: Show GRACE 4 project health across .grace context, graph, verificat
 ---
 
 <skill>
-<task>Run `grace status --path PROJECT --json` (add `--with modules` when module health is needed) and report current GRACE 4 state without mutating artifacts.</task>
+<task>Run `grace status --path PROJECT --json` and report current GRACE 4 state without mutating artifacts. Module-health summary counts are always evaluated; add `--with modules` only when detailed module records are needed.</task>
 
 <must_report>
 - Project kind: GRACE 4, legacy GRACE 3 migration candidate, or missing GRACE; plus context completeness.

--- a/plugins/grace/skills/grace/grace-verification/SKILL.md
+++ b/plugins/grace/skills/grace/grace-verification/SKILL.md
@@ -18,4 +18,7 @@ Strengthen deterministic verification for modules and changes. Verification stat
 <cwd_contract>
 When verification commands run from a workspace or package directory, add one direct `<Cwd>relative/project/path</Cwd>` child to the owning `V-M-*` entry. Keep declared `<TestFiles><File>...</File></TestFiles>` paths project-root-relative; the CLI uses `Cwd` only to compare them with cwd-relative command arguments.
 </cwd_contract>
+<evidence_contract>
+Use `<Marker>` when module health must prove a runtime log or trace emission from linked implementation code. Use `<TraceAssertion>` for deterministic test or trace evidence that does not require runtime logging, such as pure functions, type-level modules, and core libraries. A non-empty marker or trace assertion satisfies the module-health evidence requirement; only authored markers require matching runtime emission and `BLOCK_*` evidence.
+</evidence_contract>
 </skill>

--- a/scripts/packed-cli-smoke.ts
+++ b/scripts/packed-cli-smoke.ts
@@ -75,7 +75,19 @@ function writeBaseProject(root: string): void {
 //   SIDE_EFFECTS: none
 //   LINKS: M-EXAMPLE
 // END_CONTRACT: runExample
-export function runExample() { return "ok"; }
+export function runExample() {
+  console.info("[Example][run][BLOCK_RUN] packed smoke");
+  // START_BLOCK_RUN
+  return "ok";
+  // END_BLOCK_RUN
+}
+`);
+  write(root, "src/example.test.ts", `import { expect, test } from "bun:test";
+import { runExample } from "./example";
+
+test("packed smoke example", () => {
+  expect(runExample()).toBe("ok");
+});
 `);
 }
 

--- a/skills/grace/grace-status/SKILL.md
+++ b/skills/grace/grace-status/SKILL.md
@@ -4,7 +4,7 @@ description: Show GRACE 4 project health across .grace context, graph, verificat
 ---
 
 <skill>
-<task>Run `grace status --path PROJECT --json` (add `--with modules` when module health is needed) and report current GRACE 4 state without mutating artifacts.</task>
+<task>Run `grace status --path PROJECT --json` and report current GRACE 4 state without mutating artifacts. Module-health summary counts are always evaluated; add `--with modules` only when detailed module records are needed.</task>
 
 <must_report>
 - Project kind: GRACE 4, legacy GRACE 3 migration candidate, or missing GRACE; plus context completeness.

--- a/skills/grace/grace-verification/SKILL.md
+++ b/skills/grace/grace-verification/SKILL.md
@@ -18,4 +18,7 @@ Strengthen deterministic verification for modules and changes. Verification stat
 <cwd_contract>
 When verification commands run from a workspace or package directory, add one direct `<Cwd>relative/project/path</Cwd>` child to the owning `V-M-*` entry. Keep declared `<TestFiles><File>...</File></TestFiles>` paths project-root-relative; the CLI uses `Cwd` only to compare them with cwd-relative command arguments.
 </cwd_contract>
+<evidence_contract>
+Use `<Marker>` when module health must prove a runtime log or trace emission from linked implementation code. Use `<TraceAssertion>` for deterministic test or trace evidence that does not require runtime logging, such as pure functions, type-level modules, and core libraries. A non-empty marker or trace assertion satisfies the module-health evidence requirement; only authored markers require matching runtime emission and `BLOCK_*` evidence.
+</evidence_contract>
 </skill>

--- a/src/grace-query.test.ts
+++ b/src/grace-query.test.ts
@@ -207,7 +207,7 @@ describe("grace query core", () => {
     expect(resolved.module?.id).toBe("M-PROVIDER-PERSIST");
   });
 
-  it("collects explicit TestFiles/File from verification entries into query model", () => {
+  it("prefers explicit TestFiles/File entries over command-derived test paths", () => {
     const root = createProject();
     writeProjectSkeleton(root);
     writeProjectFile(
@@ -225,7 +225,7 @@ describe("grace query core", () => {
       ".grace/verification/index.xml",
       '<GraceVerificationIndex graceVersion="4.0"><VerificationDocuments><VD-MAIN><Path>verification/main.xml</Path><Owns><V-M-EXAMPLE /></Owns></VD-MAIN></VerificationDocuments></GraceVerificationIndex>',
     );
-    // Verification has both a Command with a test file reference AND explicit TestFiles/File tags
+    // Explicit TestFiles are authoritative even when the command mentions another test path.
     writeProjectFile(root, "apps/web/src/module-explicit.test.ts", "test\n");
     writeProjectFile(root, "apps/web/src/module-additional.test.ts", "test\n");
     writeProjectFile(
@@ -237,10 +237,24 @@ describe("grace query core", () => {
     const index = loadGraceArtifactIndex(root);
     const resolved = resolveVerification(index, "V-M-EXAMPLE");
     expect(resolved.verification.cwd).toBe("apps/web");
-    // Test files should include both inferred (from command) AND explicit (from TestFiles)
-    expect(resolved.verification.testFiles).toContain("apps/web/src/module.test.ts");
+    expect(resolved.verification.testFiles).not.toContain("apps/web/src/module.test.ts");
     expect(resolved.verification.testFiles).toContain("apps/web/src/module-explicit.test.ts");
     expect(resolved.verification.testFiles).toContain("apps/web/src/module-additional.test.ts");
+  });
+
+  it("does not infer glob-shaped command arguments as literal test files", () => {
+    const root = createQueryProject();
+    writeProjectFile(
+      root,
+      ".grace/verification/main.xml",
+      `<GraceVerificationDocument graceVersion="4.0"><VD-MAIN><V-M-DB><Scenario>Database client is available.</Scenario></V-M-DB><V-M-PROVIDER-PERSIST><Command>bun test src/provider/config-repo*.test.ts</Command><Scenario>Reads provider config.</Scenario><Marker>[ProviderConfigPersistence][getProviderConfig][BLOCK_GET_PROVIDER_CONFIG]</Marker></V-M-PROVIDER-PERSIST></VD-MAIN></GraceVerificationDocument>`,
+    );
+
+    const index = loadGraceArtifactIndex(root);
+    const verification = resolveVerification(index, "V-M-PROVIDER-PERSIST").verification;
+    expect(verification.testFiles).toEqual([]);
+    const health = buildModuleHealth(index, resolveModule(index, "M-PROVIDER-PERSIST"));
+    expect(health.blockers.map((blocker) => blocker.code)).not.toContain("health.verification-test-file-missing-on-disk");
   });
 
   it("uses verification Cwd when checking monorepo test command references", () => {
@@ -272,6 +286,22 @@ describe("grace query core", () => {
     const dbHealth = buildModuleHealth(index, resolveModule(index, "M-DB"));
     expect(dbHealth.state).toBe("blocked");
     expect(dbHealth.blockers.map((blocker) => blocker.code)).toContain("health.verification-missing-commands");
+  });
+
+  it("treats TraceAssertion as module-health evidence without requiring runtime logging", () => {
+    const root = createQueryProject();
+    writeProjectFile(
+      root,
+      ".grace/verification/main.xml",
+      `<GraceVerificationDocument graceVersion="4.0"><VD-MAIN><V-M-DB><Scenario>Database client is available.</Scenario></V-M-DB><V-M-PROVIDER-PERSIST><Command>bun test src/provider/config-repo.test.ts</Command><Scenario>Pure output is deterministic.</Scenario><TraceAssertion>The test proves deterministic output without runtime logging.</TraceAssertion></V-M-PROVIDER-PERSIST></VD-MAIN></GraceVerificationDocument>`,
+    );
+
+    const index = loadGraceArtifactIndex(root);
+    const verification = resolveVerification(index, "V-M-PROVIDER-PERSIST").verification;
+    expect(verification.requiredTraceAssertions).toEqual(["The test proves deterministic output without runtime logging."]);
+    const health = buildModuleHealth(index, resolveModule(index, "M-PROVIDER-PERSIST"));
+    expect(health.warnings.map((warning) => warning.code)).not.toContain("health.verification-missing-evidence");
+    expect(health.blockers.map((blocker) => blocker.code)).not.toContain("health.required-log-marker-not-found");
   });
 
   it("credits a required marker emitted through an identifier-safe constant inside nested blocks", () => {

--- a/src/grace-status.test.ts
+++ b/src/grace-status.test.ts
@@ -99,13 +99,19 @@ describe("grace status", () => {
     const root = createProject();
     writeMinimalGrace4Project(root);
 
+    const summaryOnly = collectProjectStatus(root);
     const result = collectProjectStatus(root, { includeModules: true });
 
+    expect(summaryOnly.summary.readyModules).toBe(1);
+    expect(summaryOnly.summary.attentionModules).toBe(0);
+    expect(summaryOnly.summary.blockedModules).toBe(0);
+    expect(summaryOnly.modules).toBeUndefined();
     expect(result.projectKind).toBe("grace4");
     expect(result.summary.contextArtifacts).toBe(5);
     expect(result.summary.graphModules).toBe(1);
     expect(result.summary.verificationEntries).toBe(1);
     expect(result.summary.readyModules).toBe(1);
+    expect(result.modules).toHaveLength(1);
     expect(result.nextAction).toContain("$grace-spec");
     expect(result.observedDrift.available).toBe(false);
   });

--- a/src/grace-status.ts
+++ b/src/grace-status.ts
@@ -252,11 +252,13 @@ export function collectProjectStatus(projectRoot: string, options: { includeModu
   if (observedDrift.unexplainedFiles.length > 0) derivedStates.add("unexplained-observed-drift");
 
   let modules: ModuleHealthRecord[] | undefined;
+  let evaluatedModules: ModuleHealthRecord[] | undefined;
   let moduleHealthLoadError: string | undefined;
   try {
     const index = loadGraceArtifactIndex(root);
+    evaluatedModules = collectModuleHealth(index);
     if (options.includeModules) {
-      modules = collectModuleHealth(index);
+      modules = evaluatedModules;
     }
   } catch (error) {
     moduleHealthLoadError = error instanceof Error ? error.message : String(error);
@@ -285,9 +287,9 @@ export function collectProjectStatus(projectRoot: string, options: { includeModu
       archivedChanges: changes.filter((change) => change.location === "archive").length,
       integrityErrors: integrityErrors.length,
       integrityWarnings: integrityWarnings.length,
-      readyModules: modules?.filter((module) => module.state === "ready").length ?? 0,
-      attentionModules: modules?.filter((module) => module.state === "attention").length ?? 0,
-      blockedModules: modules?.filter((module) => module.state === "blocked").length ?? 0,
+      readyModules: evaluatedModules?.filter((module) => module.state === "ready").length ?? 0,
+      attentionModules: evaluatedModules?.filter((module) => module.state === "attention").length ?? 0,
+      blockedModules: evaluatedModules?.filter((module) => module.state === "blocked").length ?? 0,
     },
     changes,
     derivedStates: [...derivedStates].sort(),

--- a/src/grace4/projections.test.ts
+++ b/src/grace4/projections.test.ts
@@ -343,7 +343,7 @@ describe("GRACE 4 graph and verification projections", () => {
     writeProjectFile(
       root,
       ".grace/verification/main.xml",
-      `<GraceVerificationDocument graceVersion="4.0"><VD-MAIN><V-M-EXAMPLE><Cwd>apps/web</Cwd><TestFiles><File>apps/web/src/example.test.ts</File></TestFiles><File>src/metadata.ts</File><Command>bun test example</Command><CommandNotes>ignored command</CommandNotes><ScenarioNotes>ignored scenario</ScenarioNotes><MarkerNotes>ignored marker</MarkerNotes></V-M-EXAMPLE></VD-MAIN></GraceVerificationDocument>`
+      `<GraceVerificationDocument graceVersion="4.0"><VD-MAIN><V-M-EXAMPLE><Cwd>apps/web</Cwd><TestFiles><File>apps/web/src/example.test.ts</File></TestFiles><File>src/metadata.ts</File><Command>bun test example</Command><CommandNotes>ignored command</CommandNotes><ScenarioNotes>ignored scenario</ScenarioNotes><MarkerNotes>ignored marker</MarkerNotes><TraceAssertion>Pure output is deterministic.</TraceAssertion><TraceAssertionNotes>ignored trace</TraceAssertionNotes></V-M-EXAMPLE></VD-MAIN></GraceVerificationDocument>`
     );
 
     const paths = resolveGrace4Paths(root);
@@ -359,6 +359,7 @@ describe("GRACE 4 graph and verification projections", () => {
     expect(entry.commands).toEqual(["bun test example"]);
     expect(entry.scenarios).toEqual([]);
     expect(entry.markers).toEqual([]);
+    expect(entry.traceAssertions).toEqual(["Pure output is deterministic."]);
   });
 
   it("rejects verification cwd values that escape the project root", () => {

--- a/src/grace4/projections.ts
+++ b/src/grace4/projections.ts
@@ -34,6 +34,7 @@ export type VerificationAnchorRecord = {
   commands: string[];
   scenarios: string[];
   markers: string[];
+  traceAssertions: string[];
   testFiles: string[];
 };
 
@@ -245,6 +246,7 @@ export function buildVerificationProjection(paths: Grace4ProjectPaths, graph: Gr
         commands: collectExactEvidence(node, "Command"),
         scenarios: collectExactEvidence(node, "Scenario"),
         markers: collectExactEvidence(node, "Marker"),
+        traceAssertions: collectExactEvidence(node, "TraceAssertion"),
         testFiles: collectTestFiles(node, paths.root, route.file, projection.issues),
       });
     }
@@ -411,7 +413,7 @@ function validateModuleVerificationCoverage(graph: GraphProjection, verification
   }
 }
 
-function collectExactEvidence(node: GraceXmlNode, tag: "Command" | "Scenario" | "Marker"): string[] {
+function collectExactEvidence(node: GraceXmlNode, tag: "Command" | "Scenario" | "Marker" | "TraceAssertion"): string[] {
   return [...walkNodes(node)]
     .filter((candidate) => candidate !== node && candidate.tag === tag)
     .map((candidate) => aggregateNodeText(candidate).trim())

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -34,6 +34,18 @@ describe("governed file analysis", () => {
     expect(analysis.issues.filter((issue) => issue.severity === "error")).toHaveLength(0);
   });
 
+  it("accepts bracketed and unbracketed LINKS lists while filtering non-module anchors", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-links-"));
+    const file = path.join(root, "src", "example.ts");
+    const links = (value: string) => parseGovernedFile(root, file, contract("NONE").replace("LINKS: M-EXAMPLE", `LINKS: ${value}`)).linkedModuleIds;
+
+    expect(links("[M-ONE]")).toEqual(["M-ONE"]);
+    expect(links("[M-ONE, M-TWO, V-M-ONE]")).toEqual(["M-ONE", "M-TWO"]);
+    expect(links("M-ONE, M-TWO, V-M-ONE")).toEqual(["M-ONE", "M-TWO"]);
+    expect(links("[none]")).toEqual([]);
+    expect(links("none")).toEqual([]);
+  });
+
   it("reports line-addressed missing, reversed, duplicate, mismatched, and overlapping markers", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "grace-markers-"));
     const file = path.join(root, "broken.ts");

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -381,7 +381,11 @@ function parseBlocks(text: string): FileBlockRecord[] {
 }
 
 function splitList(text?: string): string[] {
-  return (text ?? "").split(",").map((item) => item.trim()).filter((item) => item && item.toLowerCase() !== "none");
+  const authored = (text ?? "").trim();
+  const normalized = authored.startsWith("[") && authored.endsWith("]")
+    ? authored.slice(1, -1).trim()
+    : authored;
+  return normalized.split(",").map((item) => item.trim()).filter((item) => item && item.toLowerCase() !== "none");
 }
 
 type MarkerEvent = { direction: "start" | "end"; family: string; name: string; key: string; line: number };

--- a/src/query/core.ts
+++ b/src/query/core.ts
@@ -170,7 +170,9 @@ function toModuleGraphRecord(record: GraphAnchorRecord): ModuleGraphRecord {
 }
 
 function toModuleVerificationRecord(record: VerificationAnchorRecord): ModuleVerificationRecord {
-  const inferredTestFiles = inferTestFiles(record.commands).map((file) => qualifyVerificationPath(record.cwd, file));
+  const inferredTestFiles = record.testFiles.length === 0
+    ? inferTestFiles(record.commands).map((file) => qualifyVerificationPath(record.cwd, file))
+    : [];
   return {
     id: record.id,
     moduleId: record.moduleId,
@@ -180,7 +182,7 @@ function toModuleVerificationRecord(record: VerificationAnchorRecord): ModuleVer
     moduleChecks: record.commands,
     scenarios: record.scenarios.map((text, index) => ({ tag: "Scenario-" + (index + 1), text })),
     requiredLogMarkers: record.markers,
-    requiredTraceAssertions: [],
+    requiredTraceAssertions: record.traceAssertions,
   };
 }
 
@@ -192,7 +194,10 @@ function qualifyVerificationPath(cwd: string | undefined, file: string): string 
 }
 
 function inferTestFiles(commands: string[]) {
-  return [...new Set(commands.flatMap((command) => [...command.matchAll(/\b([^\s]+\.(?:test|spec)\.[A-Za-z0-9]+)\b/g)].map((match) => match[1])))].sort();
+  return [...new Set(commands
+    .flatMap((command) => [...command.matchAll(/\b([^\s]+\.(?:test|spec)\.[A-Za-z0-9]+)\b/g)].map((match) => match[1]!))
+    .filter((file) => ![...file].some((character) => "*?[]{}()!".includes(character))))]
+    .sort();
 }
 
 function extractNamedField(text: string, label: string) {


### PR DESCRIPTION
Fix four GRACE 4 CLI inconsistencies reproduced from a real project: support bracketed LINKS lists, project TraceAssertion evidence into module health, prevent command globs from becoming literal missing test files, and always compute module-health summary counts while keeping --with modules as the detailed-record switch. Includes regression coverage, packed CLI fixture updates, and synchronized status/verification skill contracts.