### PR TITLE
chore: prepare 4.0.3 stable release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "GRACE (Graph-RAG Anchored Code Engineering) - a methodology by Vladimir Ivanov for contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification",
-    "version": "4.0.2"
+    "version": "4.0.3"
   },
   "plugins": [
     {
       "name": "grace",
       "source": "./plugins/grace",
       "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "author": {
         "name": "osovv",
         "url": "https://github.com/osovv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## <small>4.0.3 (2026-07-26)</small>
+
+### Summary
+
+Release 4.0.3 improves CLI accuracy and verification flexibility. The `grace status` command now always evaluates module health to provide accurate summary counts (ready, attention, blocked) even when detailed module records are not requested. The verification system introduces a `<TraceAssertion>` contract, allowing modules like pure functions and core libraries to satisfy evidence requirements without requiring runtime logging or markers, reducing false positives in module health reporting. Additionally, LINKS parsing now accepts both bracketed and unbracketed list formats, explicit test file entries take precedence over command-derived paths, and glob-patterned command arguments are no longer incorrectly treated as literal test files.
+
+* fix(cli): align module health parsing and summaries ([3cb7c4f](https://github.com/osovv/grace-marketplace/commit/3cb7c4f))
+
 ## <small>4.0.2 (2026-07-26)</small>
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository ships the GRACE skills plus the optional `grace` CLI. It is a packaging and distribution repository, not an end-user application.
 
-Current packaged version: `4.0.2`
+Current packaged version: `4.0.3`
 
 ## What This Repository Ships
 

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,6 +1,6 @@
 name: grace
 description: "GRACE (Graph-RAG Anchored Code Engineering) - contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification"
-version: 4.0.2
+version: 4.0.3
 author: osovv
 license: MIT
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osovv/grace-cli",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation with a Bun-powered grace binary.",
   "license": "MIT",
   "homepage": "https://github.com/osovv/grace-marketplace#readme",

--- a/plugins/grace/.claude-plugin/plugin.json
+++ b/plugins/grace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grace",
   "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "author": {
     "name": "osovv",
     "url": "https://github.com/osovv"

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -11,7 +11,7 @@ import { verificationCommand } from "./grace-verification";
 const main = defineCommand({
   meta: {
     name: "grace",
-    version: "4.0.2",
+    version: "4.0.3",
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {


### PR DESCRIPTION
Prepare @osovv/grace-cli 4.0.3 for stable publication. After required checks pass and the pull request is merged, run `bun run release:finalize 4.0.3` from clean synchronized main to create and push the immutable release tag.