### PR TITLE
fix(lint): reject current mode in target commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For a new GRACE 4 project:
 2. Fill `.grace/context` artifacts with your agent.
 3. Run `$grace-spec` for a change.
 4. Run `$grace-plan` after spec approval.
-5. Run `grace lint --path /path/to/project --assertions current`.
+5. Before observed writes begin, run the active-baseline preflight: `grace lint --path /path/to/project --assertions current`.
 6. Run `grace lint --path /path/to/project --change C-ID --assertions baseline` before execution; add `--run-commands` when the baseline declares `MustPassCommand`.
 7. Run `grace status --path /path/to/project --json`.
 8. Run `$grace-execute` and choose sequential or parallel-safe mode. Parallel-safe mode additionally requires `grace lint --path /path/to/project --parallel-preflight`.
@@ -113,7 +113,7 @@ Migration cleanup is separately gated: successful current lint, fresh status pro
 
 | Command | What It Does |
 | --- | --- |
-| `grace lint --path <root> --assertions current` | Validate current `.grace` grammar, routed coverage, lifecycle locations, and scope overlap |
+| `grace lint --path <root> --assertions current` | Run the pre-implementation full-project check, including baselines of active approved changes; do not use it as post-edit target/final evidence |
 | `grace lint --path <root> --change C-ID --assertions baseline [--run-commands]` | Validate the immutable selected baseline before implementation; command assertions run only when explicitly enabled |
 | `grace lint --path <root> --change C-ID --assertions target --run-commands` | Validate selected target assertions and explicitly opt into `MustPassCommand` execution |
 | `grace lint --path <root> --change C-ID --assertions final [--run-commands]` | Run the final full-project gate, evaluate the selected target, and keep unrelated approved baselines active without re-evaluating the selected baseline |
@@ -125,6 +125,8 @@ Migration cleanup is separately gated: successful current lint, fresh status pro
 | `grace verification find <query> --path <root>` | Search verification projection entries |
 | `grace verification show <id-or-module> --path <root>` | Show one verification entry and module context |
 | `grace file show <path> --path <root>` | Show file-local `MODULE_CONTRACT`, `MODULE_MAP`, and `CHANGE_SUMMARY` |
+
+`MustPassCommand` entries are leaf project evidence such as tests, typecheck, build, format, or package checks. Do not nest `grace lint`, `grace status`, or another GRACE lifecycle command inside plan assertions; selected target/final lint is the external orchestration gate.
 
 Output modes:
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -17,7 +17,7 @@ grace lint --path /path/to/project --change C-ADD-AUTH --assertions target --run
 grace lint --path /path/to/project --change C-ADD-AUTH --assertions final --run-commands
 ```
 
-Current mode validates durable state. Baseline, target, and final modes require one approved identity-matched active change. Final mode is the apply/archive gate: it performs full project validation, evaluates the selected target, preserves unrelated approved baseline checks, and skips only the selected plan's superseded baseline. `MustPassCommand` remains unevaluated unless `--run-commands` is supplied.
+Current mode is the active-baseline preflight and should run only before observed writes. Baseline, target, and final modes require one approved identity-matched active change. Final mode is the outer apply/archive gate: it performs full project validation, evaluates the selected target, preserves unrelated approved baseline checks, and skips only the selected plan's superseded baseline. `MustPassCommand` remains unevaluated unless `--run-commands` is supplied and must contain leaf project checks rather than nested GRACE lifecycle commands.
 
 ## Parallel-Safe Preflight
 

--- a/plugins/grace/skills/grace/grace-cli/SKILL.md
+++ b/plugins/grace/skills/grace/grace-cli/SKILL.md
@@ -7,7 +7,7 @@ description: Operate the GRACE 4 CLI for .grace linting, status, module navigati
 <installation_contract>Invoke the installed stable `grace` binary directly. If it is missing, install it with `bun add -g @osovv/grace-cli`. Do not default to `bunx`, `npx`, or the `rc` dist-tag.</installation_contract>
 
 <commands>
-- Current lint: `grace lint --path PROJECT --assertions current`
+- Active-baseline preflight before observed writes: `grace lint --path PROJECT --assertions current`
 - Selected baseline: `grace lint --path PROJECT --change C-ID --assertions baseline` (add `--run-commands` when the baseline declares `MustPassCommand`)
 - Selected target: `grace lint --path PROJECT --change C-ID --assertions target --run-commands`
 - Final execution gate: `grace lint --path PROJECT --change C-ID --assertions final --run-commands`
@@ -15,6 +15,8 @@ description: Operate the GRACE 4 CLI for .grace linting, status, module navigati
 - Status: `grace status --path PROJECT --with modules --json`
 - Navigation: `grace module find|show`, `grace verification find|show`, and `grace file show`.
 </commands>
+
+<lifecycle_command_contract>`current` evaluates active approved baselines and is not end-state evidence. Keep `MustPassCommand` entries as leaf project checks; do not nest `grace lint`, `grace status`, or another GRACE lifecycle command inside plan assertions. Run selected target/final lint externally.</lifecycle_command_contract>
 
 <failure_contract>
 Lint, status, and navigation commands validate before returning records. JSON argument/runtime failures are one `{ "schemaVersion": "1.0.0", "ok": false, "error": { ... } }` object on stdout. Text failures are one concise actionable line with a nonzero exit code and no stack trace.

--- a/plugins/grace/skills/grace/grace-execute/SKILL.md
+++ b/plugins/grace/skills/grace/grace-execute/SKILL.md
@@ -5,11 +5,11 @@ description: Execute an approved GRACE 4 GraceChangePlan in sequential or parall
 
 <skill>
 <preflight>
-Require one active bundle with approved, identity-matched `spec.xml` and `plan.xml`. Approved plans are immutable. Read context, projections, assertions, scopes, task dependencies, and verification before editing.
+Require one active bundle with approved, identity-matched `spec.xml` and `plan.xml`. Approved plans are immutable. Read context, projections, assertions, scopes, task dependencies, and verification before editing. Reject phase-incompatible plans before writes: `MustPassCommand` must be leaf project evidence, and neither target assertions nor post-write task verification may invoke `--assertions current` or nest GRACE lifecycle commands. Supersede and replan instead of editing an approved conflict in place.
 </preflight>
 
 <assertion_commands>
-- Current validation: `grace lint --path PROJECT --assertions current`
+- Active-baseline preflight before observed writes: `grace lint --path PROJECT --assertions current`
 - Selected baseline: `grace lint --path PROJECT --change C-ID --assertions baseline` (add `--run-commands` when the baseline declares `MustPassCommand`)
 - Selected target without commands: `grace lint --path PROJECT --change C-ID --assertions target`
 - Selected target with command evidence: `grace lint --path PROJECT --change C-ID --assertions target --run-commands`
@@ -35,7 +35,7 @@ Wait for explicit `sequential` or `parallel-safe` choice. Parallel-safe requires
 2. Execute one dependency-ready task or one verified parallel-safe batch at a time.
 3. Run each task's acceptance and verification immediately.
 4. Apply approved durable context, graph, and verification changes centrally.
-5. Reconcile durable state, run plan gates, then run selected `--assertions final`, including `--run-commands` when `MustPassCommand` is declared. Final mode performs full project lint, evaluates the selected target, keeps unrelated approved baselines active, and does not re-evaluate the selected plan's superseded baseline.
+5. Reconcile durable state, run leaf plan gates, then run selected `--assertions final` as the outermost lifecycle gate, including `--run-commands` when `MustPassCommand` is declared. Final mode performs full project lint, evaluates the selected target, keeps unrelated approved baselines active, and does not re-evaluate the selected plan's superseded baseline.
 6. Ask for explicit apply confirmation after fresh end-state evidence passes.
 7. Only then set spec and plan to `applied` and archive the complete bundle.
 8. Never edit approved assertions/scopes/tasks in place, bypass stale evidence, or continue through unknown drift.

--- a/plugins/grace/skills/grace/grace-explainer/references/verification-driven-dev.md
+++ b/plugins/grace/skills/grace/grace-explainer/references/verification-driven-dev.md
@@ -82,7 +82,7 @@ logger.info("[ChatDomain][createChat][BLOCK_INSERT_CHAT] Chat created", {
 
 Execution packets in `grace-execute` should reuse these levels instead of inventing new checks ad hoc.
 
-Plan assertions use distinct evidence moments: `current` validates durable project state, selected `baseline` must pass before edits, and selected `target` must pass before apply/archive. `MustPassCommand` is deliberately opt-in through `--run-commands`; command execution is never implied by parsing a plan.
+Plan assertions use distinct evidence moments: `current` is the active-baseline preflight and is expected only before observed writes, selected `baseline` must pass immediately before edits, selected `target` proves the post-edit state, and selected `final` is the outer apply/archive gate. `MustPassCommand` is deliberately opt-in through `--run-commands` and contains leaf project evidence only; nesting `grace lint`, `grace status`, or another GRACE lifecycle command inside it is invalid.
 
 ## Autonomy Gate
 

--- a/plugins/grace/skills/grace/grace-plan/SKILL.md
+++ b/plugins/grace/skills/grace/grace-plan/SKILL.md
@@ -16,7 +16,7 @@ description: Read an approved GRACE 4 GraceChangeSpec and optional design contex
 - Require `.grace/changes/active/C-CHANGE-ID/spec.xml` with `GraceChangeSpec`, status `approved`, and exactly one matching direct `C-*` wrapper.
 - Refuse draft, rejected, cancelled, applied, or superseded specs.
 - Treat optional `design-context.xml` as explanatory; `spec.xml` wins on conflict.
-- Run `grace lint --path PROJECT --assertions current` and surface stale or invalid state before planning.
+- Run `grace lint --path PROJECT --assertions current` before planning and surface stale or invalid active baselines.
 </preflight>
 
 <approved_plan_immutability>
@@ -29,8 +29,15 @@ description: Read an approved GRACE 4 GraceChangeSpec and optional design contex
 Produce `plan.xml` from `references/change-plan-template.xml` as draft unless the user explicitly approves the completed plan. Require a matching `C-*` wrapper, meaningful intent, non-empty machine-checkable baseline and target assertions, explicit durable and observed scopes, and unique acyclic `T-NNN` tasks. A scope with no writes must use an explicit `<None />` marker; prose such as "none" is invalid. Every task has one `Title`, one `DependsOn`, non-empty acceptance criteria, and non-empty verification commands. Surface stale-state and coexistence warnings, and reject unsupported scope glob syntax instead of guessing.
 </must_do>
 
+<command_phase_rules>
+- `current` is an active-baseline preflight and is valid only before observed writes begin.
+- `baseline` is the selected pre-edit gate, `target` is selected post-edit evidence, and `final` is the outer apply/archive gate owned by `grace-execute`.
+- `MustPassCommand` contains leaf project evidence such as tests, typecheck, build, format, or package checks. Never place `grace lint`, `grace status`, or another GRACE lifecycle command inside it.
+- Never put `--assertions current` in `TargetAssertions` or in task verification that runs after writes. Use selected target/final lint externally instead.
+</command_phase_rules>
+
 <validation>
-- Current validation: `grace lint --path PROJECT --assertions current`
+- Active-baseline preflight: `grace lint --path PROJECT --assertions current`
 - Parallel safety: `grace lint --path PROJECT --parallel-preflight`
 - Recommend `grace status --path PROJECT --json` after approval.
 </validation>

--- a/plugins/grace/skills/grace/grace-plan/references/change-plan-template.xml
+++ b/plugins/grace/skills/grace/grace-plan/references/change-plan-template.xml
@@ -10,6 +10,9 @@
       <MustVerify>
         <Module>M-TARGET-MODULE</Module>
       </MustVerify>
+      <MustPassCommand>
+        <Command>bun run check</Command>
+      </MustPassCommand>
     </TargetAssertions>
     <DurableScope>
       <GraphAnchors>

--- a/plugins/grace/skills/grace/grace-spec/SKILL.md
+++ b/plugins/grace/skills/grace/grace-spec/SKILL.md
@@ -32,6 +32,6 @@ The direct `C-*` wrapper must contain exactly one meaningful `Summary`, `Goals`,
 <hard_rules>
 - `spec.xml` is the source of truth for `grace-plan`; design context never adds requirements.
 - Do not implement code, mutate current graph/verification state, or create retroactive change bundles.
-- Recommend `grace lint --path <project-root> --assertions current` after writing the bundle.
+- Recommend `grace lint --path <project-root> --assertions current` as a pre-implementation active-baseline check after writing the bundle; never present it as target or final evidence.
 </hard_rules>
 </skill>

--- a/plugins/grace/skills/grace/grace-status/SKILL.md
+++ b/plugins/grace/skills/grace/grace-status/SKILL.md
@@ -17,7 +17,7 @@ description: Show GRACE 4 project health across .grace context, graph, verificat
 </must_report>
 
 <commands>
-- Current integrity: `grace lint --path PROJECT --assertions current`
+- Pre-implementation active-baseline integrity: `grace lint --path PROJECT --assertions current`
 - Parallel decision: `grace lint --path PROJECT --parallel-preflight`
 - Status snapshot: `grace status --path PROJECT --with modules --json --fail-on errors`
 </commands>

--- a/skills/grace/grace-cli/SKILL.md
+++ b/skills/grace/grace-cli/SKILL.md
@@ -7,7 +7,7 @@ description: Operate the GRACE 4 CLI for .grace linting, status, module navigati
 <installation_contract>Invoke the installed stable `grace` binary directly. If it is missing, install it with `bun add -g @osovv/grace-cli`. Do not default to `bunx`, `npx`, or the `rc` dist-tag.</installation_contract>
 
 <commands>
-- Current lint: `grace lint --path PROJECT --assertions current`
+- Active-baseline preflight before observed writes: `grace lint --path PROJECT --assertions current`
 - Selected baseline: `grace lint --path PROJECT --change C-ID --assertions baseline` (add `--run-commands` when the baseline declares `MustPassCommand`)
 - Selected target: `grace lint --path PROJECT --change C-ID --assertions target --run-commands`
 - Final execution gate: `grace lint --path PROJECT --change C-ID --assertions final --run-commands`
@@ -15,6 +15,8 @@ description: Operate the GRACE 4 CLI for .grace linting, status, module navigati
 - Status: `grace status --path PROJECT --with modules --json`
 - Navigation: `grace module find|show`, `grace verification find|show`, and `grace file show`.
 </commands>
+
+<lifecycle_command_contract>`current` evaluates active approved baselines and is not end-state evidence. Keep `MustPassCommand` entries as leaf project checks; do not nest `grace lint`, `grace status`, or another GRACE lifecycle command inside plan assertions. Run selected target/final lint externally.</lifecycle_command_contract>
 
 <failure_contract>
 Lint, status, and navigation commands validate before returning records. JSON argument/runtime failures are one `{ "schemaVersion": "1.0.0", "ok": false, "error": { ... } }` object on stdout. Text failures are one concise actionable line with a nonzero exit code and no stack trace.

--- a/skills/grace/grace-execute/SKILL.md
+++ b/skills/grace/grace-execute/SKILL.md
@@ -5,11 +5,11 @@ description: Execute an approved GRACE 4 GraceChangePlan in sequential or parall
 
 <skill>
 <preflight>
-Require one active bundle with approved, identity-matched `spec.xml` and `plan.xml`. Approved plans are immutable. Read context, projections, assertions, scopes, task dependencies, and verification before editing.
+Require one active bundle with approved, identity-matched `spec.xml` and `plan.xml`. Approved plans are immutable. Read context, projections, assertions, scopes, task dependencies, and verification before editing. Reject phase-incompatible plans before writes: `MustPassCommand` must be leaf project evidence, and neither target assertions nor post-write task verification may invoke `--assertions current` or nest GRACE lifecycle commands. Supersede and replan instead of editing an approved conflict in place.
 </preflight>
 
 <assertion_commands>
-- Current validation: `grace lint --path PROJECT --assertions current`
+- Active-baseline preflight before observed writes: `grace lint --path PROJECT --assertions current`
 - Selected baseline: `grace lint --path PROJECT --change C-ID --assertions baseline` (add `--run-commands` when the baseline declares `MustPassCommand`)
 - Selected target without commands: `grace lint --path PROJECT --change C-ID --assertions target`
 - Selected target with command evidence: `grace lint --path PROJECT --change C-ID --assertions target --run-commands`
@@ -35,7 +35,7 @@ Wait for explicit `sequential` or `parallel-safe` choice. Parallel-safe requires
 2. Execute one dependency-ready task or one verified parallel-safe batch at a time.
 3. Run each task's acceptance and verification immediately.
 4. Apply approved durable context, graph, and verification changes centrally.
-5. Reconcile durable state, run plan gates, then run selected `--assertions final`, including `--run-commands` when `MustPassCommand` is declared. Final mode performs full project lint, evaluates the selected target, keeps unrelated approved baselines active, and does not re-evaluate the selected plan's superseded baseline.
+5. Reconcile durable state, run leaf plan gates, then run selected `--assertions final` as the outermost lifecycle gate, including `--run-commands` when `MustPassCommand` is declared. Final mode performs full project lint, evaluates the selected target, keeps unrelated approved baselines active, and does not re-evaluate the selected plan's superseded baseline.
 6. Ask for explicit apply confirmation after fresh end-state evidence passes.
 7. Only then set spec and plan to `applied` and archive the complete bundle.
 8. Never edit approved assertions/scopes/tasks in place, bypass stale evidence, or continue through unknown drift.

--- a/skills/grace/grace-explainer/references/verification-driven-dev.md
+++ b/skills/grace/grace-explainer/references/verification-driven-dev.md
@@ -82,7 +82,7 @@ logger.info("[ChatDomain][createChat][BLOCK_INSERT_CHAT] Chat created", {
 
 Execution packets in `grace-execute` should reuse these levels instead of inventing new checks ad hoc.
 
-Plan assertions use distinct evidence moments: `current` validates durable project state, selected `baseline` must pass before edits, and selected `target` must pass before apply/archive. `MustPassCommand` is deliberately opt-in through `--run-commands`; command execution is never implied by parsing a plan.
+Plan assertions use distinct evidence moments: `current` is the active-baseline preflight and is expected only before observed writes, selected `baseline` must pass immediately before edits, selected `target` proves the post-edit state, and selected `final` is the outer apply/archive gate. `MustPassCommand` is deliberately opt-in through `--run-commands` and contains leaf project evidence only; nesting `grace lint`, `grace status`, or another GRACE lifecycle command inside it is invalid.
 
 ## Autonomy Gate
 

--- a/skills/grace/grace-plan/SKILL.md
+++ b/skills/grace/grace-plan/SKILL.md
@@ -16,7 +16,7 @@ description: Read an approved GRACE 4 GraceChangeSpec and optional design contex
 - Require `.grace/changes/active/C-CHANGE-ID/spec.xml` with `GraceChangeSpec`, status `approved`, and exactly one matching direct `C-*` wrapper.
 - Refuse draft, rejected, cancelled, applied, or superseded specs.
 - Treat optional `design-context.xml` as explanatory; `spec.xml` wins on conflict.
-- Run `grace lint --path PROJECT --assertions current` and surface stale or invalid state before planning.
+- Run `grace lint --path PROJECT --assertions current` before planning and surface stale or invalid active baselines.
 </preflight>
 
 <approved_plan_immutability>
@@ -29,8 +29,15 @@ description: Read an approved GRACE 4 GraceChangeSpec and optional design contex
 Produce `plan.xml` from `references/change-plan-template.xml` as draft unless the user explicitly approves the completed plan. Require a matching `C-*` wrapper, meaningful intent, non-empty machine-checkable baseline and target assertions, explicit durable and observed scopes, and unique acyclic `T-NNN` tasks. A scope with no writes must use an explicit `<None />` marker; prose such as "none" is invalid. Every task has one `Title`, one `DependsOn`, non-empty acceptance criteria, and non-empty verification commands. Surface stale-state and coexistence warnings, and reject unsupported scope glob syntax instead of guessing.
 </must_do>
 
+<command_phase_rules>
+- `current` is an active-baseline preflight and is valid only before observed writes begin.
+- `baseline` is the selected pre-edit gate, `target` is selected post-edit evidence, and `final` is the outer apply/archive gate owned by `grace-execute`.
+- `MustPassCommand` contains leaf project evidence such as tests, typecheck, build, format, or package checks. Never place `grace lint`, `grace status`, or another GRACE lifecycle command inside it.
+- Never put `--assertions current` in `TargetAssertions` or in task verification that runs after writes. Use selected target/final lint externally instead.
+</command_phase_rules>
+
 <validation>
-- Current validation: `grace lint --path PROJECT --assertions current`
+- Active-baseline preflight: `grace lint --path PROJECT --assertions current`
 - Parallel safety: `grace lint --path PROJECT --parallel-preflight`
 - Recommend `grace status --path PROJECT --json` after approval.
 </validation>

--- a/skills/grace/grace-plan/references/change-plan-template.xml
+++ b/skills/grace/grace-plan/references/change-plan-template.xml
@@ -10,6 +10,9 @@
       <MustVerify>
         <Module>M-TARGET-MODULE</Module>
       </MustVerify>
+      <MustPassCommand>
+        <Command>bun run check</Command>
+      </MustPassCommand>
     </TargetAssertions>
     <DurableScope>
       <GraphAnchors>

--- a/skills/grace/grace-spec/SKILL.md
+++ b/skills/grace/grace-spec/SKILL.md
@@ -32,6 +32,6 @@ The direct `C-*` wrapper must contain exactly one meaningful `Summary`, `Goals`,
 <hard_rules>
 - `spec.xml` is the source of truth for `grace-plan`; design context never adds requirements.
 - Do not implement code, mutate current graph/verification state, or create retroactive change bundles.
-- Recommend `grace lint --path <project-root> --assertions current` after writing the bundle.
+- Recommend `grace lint --path <project-root> --assertions current` as a pre-implementation active-baseline check after writing the bundle; never present it as target or final evidence.
 </hard_rules>
 </skill>

--- a/skills/grace/grace-status/SKILL.md
+++ b/skills/grace/grace-status/SKILL.md
@@ -17,7 +17,7 @@ description: Show GRACE 4 project health across .grace context, graph, verificat
 </must_report>
 
 <commands>
-- Current integrity: `grace lint --path PROJECT --assertions current`
+- Pre-implementation active-baseline integrity: `grace lint --path PROJECT --assertions current`
 - Parallel decision: `grace lint --path PROJECT --parallel-preflight`
 - Status snapshot: `grace status --path PROJECT --with modules --json --fail-on errors`
 </commands>

--- a/src/grace-lint.test.ts
+++ b/src/grace-lint.test.ts
@@ -343,6 +343,43 @@ describe("lintGraceProject", () => {
     expect(JSON.parse(Buffer.from(cli.stdout).toString("utf8")).assertionMode).toBe("target");
   });
 
+  it("rejects target command evidence that recursively invokes current baseline lint", () => {
+    const root = createProject();
+    writeMinimalGrace4Project(root);
+    writeApprovedChange(
+      root,
+      "C-PHASE-CONFLICT",
+      `<MustExist><Value>M-EXAMPLE</Value></MustExist>`,
+      `<MustPassCommand><Command>grace lint --path . --assertions current</Command></MustPassCommand>`,
+    );
+
+    const current = lintGraceProject(root);
+    const issue = current.issues.find((item) => item.code === "assertion.phase-incompatible-command");
+    expect(issue?.message).toContain("leaf project evidence");
+    expect(issue?.title).toContain("Phase-Incompatible");
+
+    const final = lintGraceProject(root, { assertionMode: "final", changeId: "C-PHASE-CONFLICT", runCommands: true });
+    expect(final.issues.map((item) => item.code)).toContain("assertion.phase-incompatible-command");
+    expect(final.issues.map((item) => item.code)).not.toContain("assertion.MustPassCommand");
+  });
+
+  it("does not apply new phase policy retroactively to archived plans", () => {
+    const root = createProject();
+    writeMinimalGrace4Project(root);
+    writeProjectFile(
+      root,
+      ".grace/changes/archive/C-HISTORICAL/spec.xml",
+      `<GraceChangeSpec graceVersion="4.0" status="applied"><C-HISTORICAL><Summary>Historical change.</Summary><Goals><Goal>Preserve history.</Goal></Goals><Constraints><Constraint>Do not rewrite archives.</Constraint></Constraints><NonGoals><NonGoal>New behavior.</NonGoal></NonGoals><AcceptanceCriteria><Criterion>History remains readable.</Criterion></AcceptanceCriteria><AffectedAreas><M-EXAMPLE /></AffectedAreas><VerificationIntent><ExpectedCommand>bun test</ExpectedCommand></VerificationIntent></C-HISTORICAL></GraceChangeSpec>`,
+    );
+    writeProjectFile(
+      root,
+      ".grace/changes/archive/C-HISTORICAL/plan.xml",
+      `<GraceChangePlan graceVersion="4.0" status="applied"><C-HISTORICAL><IntentSummary>Historical plan.</IntentSummary><BaselineAssertions><MustExist><Value>M-EXAMPLE</Value></MustExist></BaselineAssertions><TargetAssertions><MustPassCommand><Command>grace lint --path . --assertions current</Command></MustPassCommand></TargetAssertions><DurableScope><GraphAnchors><M-EXAMPLE /></GraphAnchors></DurableScope><ObservedWriteScope><File>src/example.ts</File></ObservedWriteScope><ImplementationPlan><T-001><Title>Historical task</Title><DependsOn></DependsOn><AcceptanceCriteria><Criterion>Done.</Criterion></AcceptanceCriteria><Verification><Command>bun test</Command></Verification></T-001></ImplementationPlan></C-HISTORICAL></GraceChangePlan>`,
+    );
+
+    expect(lintGraceProject(root).issues.map((item) => item.code)).not.toContain("assertion.phase-incompatible-command");
+  });
+
   it("reserves blocking overlap diagnostics for explicit parallel preflight", () => {
     const root = createProject();
     writeMinimalGrace4Project(root);

--- a/src/grace-lint.ts
+++ b/src/grace-lint.ts
@@ -113,7 +113,7 @@ export const lintCommand = defineCommand({
     },
     assertions: {
       type: "string",
-      description: "Assertion mode: current, baseline, target, or final",
+      description: "Assertion mode: current (pre-write active baselines), baseline, target, or final",
       default: "current",
     },
     runCommands: {

--- a/src/grace4/assertions.test.ts
+++ b/src/grace4/assertions.test.ts
@@ -124,6 +124,20 @@ describe("GRACE 4 assertions", () => {
     expect(result.issues.map((item) => item.code)).toContain("assertion.empty-section");
   });
 
+  it("rejects current-mode lifecycle lint nested inside target command evidence", () => {
+    const root = createProject();
+    const planFile = path.join(root, "plan.xml");
+    writeFileSync(
+      planFile,
+      `<GraceChangePlan graceVersion="4.0" status="approved"><C-EXAMPLE><TargetAssertions><MustPassCommand><Command>grace lint --path . --assertions current</Command><Command>bun run check</Command></MustPassCommand></TargetAssertions></C-EXAMPLE></GraceChangePlan>`,
+    );
+
+    const result = extractAssertionsWithIssues(planFile, "TargetAssertions");
+    expect(result.issues.map((item) => item.code)).toContain("assertion.phase-incompatible-command");
+    expect(result.assertions).toHaveLength(0);
+    expect(result.issues.map((item) => item.code)).not.toContain("assertion.empty-section");
+  });
+
   it("rejects absolute, traversal, and escaping-symlink File fields during extraction", () => {
     const root = createProject();
     const outside = createProject();

--- a/src/grace4/assertions.ts
+++ b/src/grace4/assertions.ts
@@ -123,6 +123,12 @@ export function extractAssertionsWithIssues(
       if (!extraction.assertion) {
         continue;
       }
+      const phaseIssues = validateAssertionPhase(planFile, section, extraction.assertion);
+      issues.push(...phaseIssues);
+      if (phaseIssues.length > 0) {
+        validAssertions += 1;
+        continue;
+      }
       assertions.push({
         ...extraction.assertion,
         file: planFile,
@@ -135,6 +141,25 @@ export function extractAssertionsWithIssues(
   }
 
   return { assertions, issues };
+}
+
+function validateAssertionPhase(
+  planFile: string,
+  section: "BaselineAssertions" | "TargetAssertions",
+  assertion: Omit<GraceAssertion, "file">,
+): Grace4Issue[] {
+  if (section !== "TargetAssertions" || assertion.kind !== "MustPassCommand") {
+    return [];
+  }
+
+  return assertion.values
+    .filter((command) => /(?:^|\s)--assertions(?:\s+|=)(?:current|["']current["'])(?=\s|$|[;&|])/i.test(command))
+    .map((command) => issue(
+      "error",
+      "assertion.phase-incompatible-command",
+      planFile,
+      `TargetAssertions MustPassCommand must not invoke --assertions current: ${command}. Current mode evaluates active approved baselines and becomes stale after target writes; keep MustPassCommand as leaf project evidence and run selected target/final lint as the outer gate.`,
+    ));
 }
 
 function evaluateMustOwn(assertion: GraceAssertion, context: AssertionContext): Grace4Issue[] {

--- a/src/lint/catalog.ts
+++ b/src/lint/catalog.ts
@@ -48,6 +48,11 @@ const EXACT_GUIDES: Record<string, Omit<LintIssueGuide, "code">> = {
     explanation: "A GraceChangeSpec or GraceChangePlan with status='superseded' should name the replacement C-* anchor via a <Replacement> or <ReplacementChange> child tag.",
     remediation: ["Add a <Replacement>C-REPLACEMENT-ID</Replacement> child to the superseded wrapper.", "Or add a direct <C-REPLACEMENT-ID /> child tag as the replacement reference."],
   },
+  "assertion.phase-incompatible-command": {
+    title: "Phase-Incompatible Assertion Command",
+    explanation: "A target command assertion invokes current-mode lifecycle lint. Current mode evaluates active approved baselines, so it is a pre-implementation check and cannot serve as target or final evidence after writes begin.",
+    remediation: ["Keep MustPassCommand entries as leaf project evidence such as tests, typecheck, build, format, or package checks.", "Run selected target or final GRACE lint as the outer execution gate instead of nesting it inside the plan."],
+  },
 };
 
 const PREFIX_GUIDES: Array<{ prefix: string; title: string; explanation: string; remediation: string[] }> = [

--- a/src/lint/core.ts
+++ b/src/lint/core.ts
@@ -128,8 +128,8 @@ function validateAssertions(
 
   for (const planFile of planFilesArchived) {
     // Archived plans: syntax only, never semantic (baseline may be stale, target may be superseded by later changes)
-    evaluateSection(result, planFile, "BaselineAssertions", context, false);
-    evaluateSection(result, planFile, "TargetAssertions", context, false);
+    evaluateSection(result, planFile, "BaselineAssertions", context, false, true, false, true);
+    evaluateSection(result, planFile, "TargetAssertions", context, false, true, false, true);
   }
 
   if (assertionMode === "current") {
@@ -157,10 +157,14 @@ function evaluateSection(
   evaluateSemantically: boolean,
   includeExtractionIssues = true,
   skipUnevaluatedCommands = false,
+  skipActivePhaseIssues = false,
 ) {
   const extraction = extractAssertionsWithIssues(planFile, section);
   if (includeExtractionIssues) {
     for (const issue of extraction.issues) {
+      if (skipActivePhaseIssues && issue.code === "assertion.phase-incompatible-command") {
+        continue;
+      }
       addGrace4Issue(result, issue);
     }
   }


### PR DESCRIPTION
Prevent self-contradictory GRACE lifecycle plans by rejecting TargetAssertions MustPassCommand entries that invoke --assertions current. The new diagnostic is active-plan-only, skips historical archived bundles, and avoids executing the invalid command. Also clarifies current/baseline/target/final phase semantics across canonical and packaged skills, the plan template, README, and CLI examples.