### PR TITLE
chore: prepare 4.0.4 stable release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "GRACE (Graph-RAG Anchored Code Engineering) - a methodology by Vladimir Ivanov for contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification",
-    "version": "4.0.3"
+    "version": "4.0.4"
   },
   "plugins": [
     {
       "name": "grace",
       "source": "./plugins/grace",
       "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "author": {
         "name": "osovv",
         "url": "https://github.com/osovv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## <small>4.0.4 (2026-07-27)</small>
+
+### Summary
+
+This release fixes a lint gap that could silently accept phase-incompatible command evidence, preventing `--assertions current` from being used inside target assertions or `MustPassCommand` entries, which are meant only for leaf project checks like tests and builds—this enforces the intended execution lifecycle where current mode is strictly a pre-write active-baseline check and keeps the plan phase rules unambiguous for all users. CI workflows are updated to run on Node 24 with the latest official action versions, ensuring continued compatibility and faster validation.
+
+* fix(lint): reject current mode in target commands ([429a03d](https://github.com/osovv/grace-marketplace/commit/429a03d))
+* chore(ci): run official actions on Node 24 ([aa9cd17](https://github.com/osovv/grace-marketplace/commit/aa9cd17))
+* chore(ci): run setup-python on Node 24 ([bdbd376](https://github.com/osovv/grace-marketplace/commit/bdbd376))
+
 ## <small>4.0.3 (2026-07-26)</small>
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository ships the GRACE skills plus the optional `grace` CLI. It is a packaging and distribution repository, not an end-user application.
 
-Current packaged version: `4.0.3`
+Current packaged version: `4.0.4`
 
 ## What This Repository Ships
 

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,6 +1,6 @@
 name: grace
 description: "GRACE (Graph-RAG Anchored Code Engineering) - contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification"
-version: 4.0.3
+version: 4.0.4
 author: osovv
 license: MIT
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osovv/grace-cli",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation with a Bun-powered grace binary.",
   "license": "MIT",
   "homepage": "https://github.com/osovv/grace-marketplace#readme",

--- a/plugins/grace/.claude-plugin/plugin.json
+++ b/plugins/grace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grace",
   "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "author": {
     "name": "osovv",
     "url": "https://github.com/osovv"

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -11,7 +11,7 @@ import { verificationCommand } from "./grace-verification";
 const main = defineCommand({
   meta: {
     name: "grace",
-    version: "4.0.3",
+    version: "4.0.4",
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {


### PR DESCRIPTION
Prepare @osovv/grace-cli 4.0.4 for stable publication. After required checks pass and the pull request is merged, run `bun run release:finalize 4.0.4` from clean synchronized main to create and push the immutable release tag.