### PR TITLE
feat(afk): autonomous AFK mode with CLI-enforced budget and Telegram escalations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,9 @@
         "./skills/grace/grace-explainer",
         "./skills/grace/grace-verification",
         "./skills/grace/grace-reviewer",
-        "./skills/grace/grace-migrate"
+        "./skills/grace/grace-migrate",
+        "./skills/grace/grace-afk",
+        "./skills/grace/grace-ask-human"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Migration cleanup is separately gated: successful current lint, fresh status pro
 | `grace-verification` | Build and maintain `.grace/verification` entries and evidence |
 | `grace-reviewer` | Review semantic integrity, projections, scopes, and verification quality |
 | `grace-migrate` | Agent-applied GRACE 3 to GRACE 4 migration with CLI validation |
+| `grace-afk` | Autonomous work mode with a CLI-enforced time budget and an autonomy matrix for act/defer/escalate decisions |
+| `grace-ask-human` | Telegram escalation for one-way-door decisions during autonomous sessions |
 
 ## CLI Overview
 
@@ -125,6 +127,11 @@ Migration cleanup is separately gated: successful current lint, fresh status pro
 | `grace verification find <query> --path <root>` | Search verification projection entries |
 | `grace verification show <id-or-module> --path <root>` | Show one verification entry and module context |
 | `grace file show <path> --path <root>` | Show file-local `MODULE_CONTRACT`, `MODULE_MAP`, and `CHANGE_SUMMARY` |
+| `grace afk start <hours> [<budget%>] [--checkpoint <min>]` | Start an autonomous session — creates isolated branch + `state.json` with `expiresAt` |
+| `grace afk tick` | CLI-side active-session gate. Exits `42 BUDGET_EXHAUSTED`, `43 NO_SESSION`, `44 SESSION_STOPPED`. The agent polls between every step |
+| `grace afk ask / check` | Send a Telegram escalation (needs Telegram config at `$GRACE_AFK_CONFIG`, `<project>/.grace-afk.json`, or `~/.grace/afk.json`), poll for reply |
+| `grace afk journal / defer / increment` | Append structured entries to `docs/afk-sessions/<id>/{decisions,deferred}.md` and update counters |
+| `grace afk report / stop` | Emit the return dashboard / manually stop a session |
 
 `MustPassCommand` entries are leaf project evidence such as tests, typecheck, build, format, or package checks. Do not nest `grace lint`, `grace status`, or another GRACE lifecycle command inside plan assertions; selected target/final lint is the external orchestration gate.
 

--- a/docs/diagrams/grace-afk-loop.md
+++ b/docs/diagrams/grace-afk-loop.md
@@ -1,0 +1,57 @@
+# `grace-afk` autopilot loop
+
+Visual reference for the `grace-afk` skill (see `skills/grace/grace-afk/SKILL.md`).
+GitHub renders the mermaid block inline.
+
+## The loop
+
+```mermaid
+flowchart TD
+    Start([User: /afk 8 20]) --> CreateSess["grace afk start<br/>• tag baseline<br/>• branch afk-TS<br/>• write state.json with expiresAt"]
+    CreateSess --> Tick{"grace afk tick<br/>exit code"}
+
+    Tick -->|"0 — active"| NextStep["Pick next pending T-task<br/>from .grace/changes/active plan"]
+    Tick -->|"42 — BUDGET_EXHAUSTED"| Report["grace afk report<br/>(dashboard)"]
+    Tick -->|"44 — stopped"| Report
+
+    NextStep --> Classify{"Autonomy matrix:<br/>decision class?"}
+
+    Classify -->|"reversible"| Act["invoke grace-fix /<br/>grace-execute /<br/>grace-refactor<br/>→ commit on afk branch"]
+    Classify -->|"one-way door"| Ask["grace afk ask<br/>→ Telegram"]
+    Classify -->|"scope creep"| Defer["grace afk defer<br/>→ deferred.md"]
+    Classify -->|"threshold yellow"| Rollback["git reset --hard<br/>on afk branch"]
+
+    Act --> Gates{"bun test<br/>+ grace lint"}
+    Gates -->|"green"| Tick
+    Gates -->|"yellow"| Rollback
+    Gates -->|"red"| Ask
+
+    Ask -->|"A / B / PROCEED"| Act
+    Ask -->|"STOP"| StopCmd["grace afk stop"]
+    Ask -->|"no reply 2h"| Defer
+
+    StopCmd --> Report
+    Defer --> Tick
+    Rollback --> Tick
+
+    Report --> End(["Session complete:<br/>human reviews deferred.md,<br/>merges afk-TS branch"])
+```
+
+## How to read it
+
+- **Rectangles** — actions (CLI commands, git operations).
+- **Diamonds** — decision forks (tick gate, autonomy matrix, gates).
+- The central **`grace afk tick` gate** is the "clock you cannot fast-forward": control returns
+  there after every action. The CLI, not the LLM, decides when the session ends.
+- The **red path through Telegram** is the only way out of autopilot mid-session: the agent only
+  pages the human for genuinely irreversible decisions (one-way doors) or hard-red gate failures.
+- **`deferred.md`** is the log of questions the agent chose not to answer. On return, the human
+  reads it first, then merges the `afk-TS` branch.
+
+## Related
+
+- `skills/grace/grace-afk/SKILL.md` — protocol the agent follows inside the loop.
+- `skills/grace/grace-ask-human/SKILL.md` — message format for the Telegram escalation box.
+- `src/grace-afk.ts` — CLI wiring that owns the state transitions shown here.
+- `src/afk/session.ts` — atomic state.json writes and the exit-code constants.
+- `PLAN.md` → "PR-3 `grace-afk`" section — design rationale.

--- a/plugins/grace/skills/grace/grace-afk/SKILL.md
+++ b/plugins/grace/skills/grace/grace-afk/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: grace-afk
+description: "Autonomous work mode for when the user is AFK. Use when the user types `/afk [hours] [budget%] [--checkpoint <min>]` or asks the agent to keep working on its own. The CLI enforces the time budget — the agent polls `grace afk tick` between steps and stops when the CLI says so. One-way-door decisions are escalated to Telegram via `grace afk ask`; everything else is acted on, deferred, or rolled back per the autonomy matrix."
+---
+
+Run the /afk harness: keep working through the active GRACE 4 change plan
+(`.grace/changes/active/C-*/plan.xml`) on an isolated branch,
+making decisions from the user on their behalf within declared boundaries, until the CLI-enforced
+budget expires or the user sends STOP via Telegram.
+
+<EXTREMELY-IMPORTANT>
+You are NOT the budget tracker. The CLI is.
+
+Between every logical step you MUST run `grace afk tick --path <project-root>`. If it exits
+non-zero, your session is over — commit the in-progress work (if any), run `grace afk report`,
+and stop. Do NOT try to estimate remaining budget yourself and keep going. The hard gate is
+the CLI exit code.
+</EXTREMELY-IMPORTANT>
+
+## Prerequisites
+
+- Project is GRACE 4-managed (`.grace/` exists). If it is still on the GRACE 3 `docs/*.xml` layout, run `$grace-migrate` first; if it has no GRACE at all, run `$grace-init` first.
+- `@osovv/grace-cli` installed (the binary `grace` is on PATH).
+- Telegram config resolved by lookup priority: `$GRACE_AFK_CONFIG` env var, then `<project>/.grace-afk.json`, then `~/.grace/afk.json` (global user-level fallback). Configure one of these if `grace-ask-human` escalations are expected — otherwise one-way-door decisions fall back to `grace afk defer`.
+
+## Command Surface (CLI)
+
+Every subcommand below takes `--path <project-root>` (defaults to `.`).
+
+| Command | Purpose |
+|---|---|
+| `grace afk start <hours> [<budget%>] [--checkpoint <min>]` | Initialize a session; writes `docs/afk-sessions/<id>/state.json` with `expiresAt`. |
+| `grace afk tick` | CLI-side active-session check. Non-zero exit = session over. |
+| `grace afk ask --title ... --context ... --options "A:...;B:..." --mypick B --confidence 60 [--details "A\|pros\|cons\|opps\|risks;B\|..."] [--wait 120]` | Send a Telegram escalation; returns `{correlationId, messageId}`. Use `;` as a separator (safer across Windows shells) or `\|`. `--details` (5-field SWOT per option) adds a `[📖 Details]` button that sends a follow-up breakdown without cancelling the ask. `--wait N` blocks up to N seconds polling, ack-ing inline-button taps within ~2s so the user's Telegram spinner stops immediately. |
+| `grace afk check --correlation <id> --messageid <n> [--offset <o>]` | Poll Telegram; returns `{status, verb, raw, nextOffset}`. |
+| `grace afk journal --class <c> --title ... --rationale ... --outcome ...` | Append to `decisions.md`. |
+| `grace afk defer --question ... --contextLine ...` | Append to `deferred.md`. |
+| `grace afk increment <commits\|escalations\|deferred>` | Update session counters after an action. |
+| `grace afk report` | Print the return dashboard and mark session completed. |
+| `grace afk stop --reason "..."` | Manual stop (e.g. when user sends `STOP` in Telegram). |
+
+Exit codes from `tick`:
+- `0` — session active, continue
+- `42` — `BUDGET_EXHAUSTED` (time expired)
+- `43` — no active session
+- `44` — session was stopped
+- `45` — Telegram sendMessage failed (only from `ask`)
+- `46` — grace-afk config missing at env var, project root, and `~/.grace/afk.json` (only from `ask` / `check`)
+- `2`  — bad arguments (unknown --class, missing --context, etc.)
+
+### Windows-specific note on exit codes
+
+On Windows, if the agent invokes `bun run ./src/grace.ts afk tick` via a shell
+wrapper, `bun run` can squash custom exit codes into `1` or `255`. Two defences:
+
+1. Prefer invoking `bun <file>` directly (no `run` verb) when spawning subprocesses
+   from the harness.
+2. Also parse the first line of stderr as a fallback — `tick` prints the reason
+   before exiting (`Budget exhausted`, `no active session`, `stopped`). If the
+   numeric code is squashed to 1/255, the stderr line still disambiguates.
+
+The agent must NOT assume a non-zero exit is always `BUDGET_EXHAUSTED`. Check the
+value first; if it is 1 or 255, read stderr to disambiguate before acting.
+
+## Startup Protocol
+
+1. Parse the user's `/afk [hours] [budget%] [--checkpoint <m>]` invocation. Defaults: `hours=2`,
+   `budget%=default`, `checkpoint=30`.
+2. **Create isolation:**
+   - `git tag afk-baseline-<timestamp>`
+   - `git checkout -b afk-<timestamp>` from the current branch tip
+3. **Start session:** `grace afk start <hours> [<budget%>] [--checkpoint <min>] --path .`
+4. **Announce to user** (single line): session id, expiresAt, first step to be worked.
+5. Enter the loop.
+
+## The Loop
+
+Every iteration:
+
+1. **Tick.** Run `grace afk tick --path .`. Non-zero exit → jump to "End of session" below.
+2. **Pick next task.** Read the active change bundle in `.grace/changes/active/C-*/`: take the
+   approved `plan.xml`, find the first pending `T-NNN` task in `<ImplementationPlan>` whose
+   `<DependsOn>` tasks are all done. If none, jump to "End of session". If several bundles are
+   active, work them one at a time, in `C-*` id order.
+3. **Route via autonomy matrix** (see below). Act / defer / escalate.
+4. **If acting:** execute the task (invoke the appropriate `grace-*` skill — usually
+   `grace-execute` for the next plan task, or `grace-fix` for a bug). Commit the result with the
+   project's usual message convention, referencing the change id and task id. Run `grace afk increment commits`.
+5. **Record decision.** `grace afk journal --class <c> --title ... --rationale ... --outcome ...`.
+6. **Verify gates.** Run the project's test command and `grace lint --path . --assertions current`.
+   The green/yellow/red gate logic applies even in single-task mode:
+   - green → next iteration
+   - yellow → rollback the step (`git reset --hard HEAD~1` on your afk branch ONLY), journal the rollback,
+     next iteration
+   - red → escalate to Telegram if budget allows; else defer and stop
+7. **Checkpoint check.** If `checkpointMinutes` have passed since start or last checkpoint, run
+   a summary (tick, lint, journal entry `class=checkpoint`).
+
+## Autonomy Matrix
+
+| Class | Trigger | Action |
+|---|---|---|
+| `reversible-act` | Obvious implementation step; well-defined contract; single credible approach | **Act** — invoke `grace-execute` or `grace-fix`; journal; continue. |
+| `uncertain-deferred` | Multiple credible approaches with different tradeoffs, no obvious winner | **Defer** to `deferred.md` with a note on the competing approaches. |
+| `one-way-door-escalated` | Irreversible or main-branch-affecting: push to main, force push, drop DB, deploy, external API side-effects, changing a public MODULE_CONTRACT | **`grace afk ask`** via Telegram; poll `grace afk check` with backoff 10 / 30 / 60 / 120 min. |
+| `one-way-door-deferred` | Same as above but Telegram unavailable OR max escalations already sent | **Defer** and move to next step. |
+| `scope-creep-deferred` | The step's description would pull in edits outside the declared write scope | **Always defer**, never act. |
+| `threshold-yellow-rollback` | Tests / lint / graph consistency between green and red | Rollback + next step. |
+| `threshold-red-escalated` | Hard fail on any gate | Telegram ask with options `ROLLBACK / STOP`; default to ROLLBACK on timeout. |
+| `checkpoint` | Periodic summary | Journal entry; never an action. |
+
+Rule (anti-Goodhart): "one-way door" is a **behavioural test**, not a feeling. If a single
+`git reset --hard afk-baseline-<ts>` cannot fully undo the action, it is one-way. If the action
+is file edits on the `afk-*` branch only — it is reversible, act freely.
+
+## Telegram Escalation Format
+
+Delegated to `$grace-ask-human`. Key rules:
+- Short (≤10 lines). No prose summaries.
+- A/B/C options, 1 line each.
+- State your current pick + confidence.
+- User replies with one of: `A B C D E PROCEED STOP EVOLVE DEFER` (case-insensitive, any position).
+- Polling: 10min → 30min → 60min → 120min. No reply after 120min → fall through: if the ask was
+  `uncertain` → defer; if `one-way-door` with no default → stop the session; if `threshold-red`
+  with ROLLBACK as option → rollback.
+
+Hard cap: **3 escalations per session** (enforced by CLI via `--autoStop.maxEscalationsPerSession`).
+Past that, you must defer remaining one-way-door decisions.
+
+## Idle-fill: review while awaiting a reply
+
+While a `grace afk ask` is outstanding and you are polling `grace afk check` (the 10/30/60/120 min
+backoff is long idle time), do NOT sit idle — spend it on a **read-only** `$grace-reviewer` pass over
+the work done so far on the `afk-*` branch (5 axes + `grace lint --path .`). Queue findings in the
+journal (`grace afk journal --class review ...`); do not block on them.
+
+Guardrails:
+- **Read-only by default.** Apply only clearly-reversible fixes that are in-scope AND unrelated to the
+  question under escalation. Anything touching the escalated decision waits for the answer.
+- **Interruptible.** The moment `grace afk check` returns a verb, drop the review immediately and act
+  on the reply. Never make the user wait on a review.
+- Keep running `grace afk tick` between review chunks — the budget clock keeps running during the wait.
+
+## STOP handling
+
+If you see `grace afk check` return `{verb: "STOP"}`, immediately:
+1. Commit any in-progress work (with message `grace(afk): checkpoint before STOP`).
+2. Run `grace afk stop --reason "user STOP via telegram"`.
+3. Run `grace afk report`.
+4. Exit the loop. Do not take further actions.
+
+## End of Session
+
+Triggered by: `tick` non-zero, user STOP, plan exhausted, hard block (e.g. CLI failure).
+
+1. Ensure working tree is committed (or stashed with a descriptive name).
+2. **Final review.** Run a `$grace-reviewer` integrity pass over the whole `afk-*` branch (all 5 axes)
+   plus `grace lint --path .`. Fold the findings (with severities) into the return dashboard so the
+   human sees the QUALITY of the work, not just the list of commits. Journal it
+   (`grace afk journal --class review ...`). Read-only — do NOT auto-fix at end of session; let the
+   human decide what to act on.
+3. Run `grace afk report --path .` (this marks the session completed).
+4. Announce to the user: branch name, session id, deferred count, commits count, **review summary**,
+   next suggested action (usually: review `deferred.md` + the review findings, then merge `afk-<ts>`
+   into the target feature branch).
+5. Do not delete the `afk-<ts>` branch — leave it for human review.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I can estimate budget better than the CLI" | You can't. LLM math on token consumption is unreliable and biased toward continuing. The CLI has the real clock. |
+| "This one decision is borderline one-way, I'll just act" | Borderline = defer. Over a long session, "just act" on every borderline becomes the majority of decisions and you end up with un-reviewable diffs. |
+| "Telegram escalation is overkill for this small choice" | If it is small, it is not a one-way door — act, do not escalate. If it is one-way, it is not small. |
+| "The reviewer will catch anything bad" | There is no reviewer. You are alone. The human will see only the final diff + journal. Be conservative. |
+| "I'll skip the journal entry for trivial steps" | The journal is how the human reconstructs what you did. Trivial steps are the ones most likely to be questioned on return. |
+| "I should check budget every minute just in case" | Every tick burns API cost. Call tick between logical steps, not inside tight loops. |
+| "The plan task is too vague, I'll reinterpret it" | Vague plan task = `scope-creep-deferred`. Do not reinterpret; defer and let the human clarify. |
+
+## Red Flags
+
+- You are about to edit a file outside the declared write scope of the current plan step.
+- You are considering `git push` or anything that touches `main` / `master`.
+- You are about to change a MODULE_CONTRACT without a Telegram ask.
+- You have not run `grace afk tick` in the last 15 minutes.
+- You have escalated more than 3 times in one session.
+- You are editing `docs/afk-sessions/<id>/state.json` by hand (never do this — use CLI commands).
+
+## When NOT to Use
+
+- The user is present and actively iterating. `/afk` is for unattended work.
+- The plan is unclear or missing. Run `$grace-plan` first.
+- There are no pending `T-NNN` tasks in the active change plan. Nothing to do.
+- Verification coverage is skeletal. Without `V-M-*` entries, the "verify gates" step has no teeth.
+- Less than 30 minutes of intended autonomy — just keep working in the foreground instead.
+
+## Verification
+
+Before exiting, confirm:
+
+- [ ] Session state shows `status=completed` or `status=stopped` (verification: `cat docs/afk-sessions/<id>/state.json | jq .status`)
+- [ ] All in-progress code committed on `afk-<ts>` branch (verification: `git status` clean on that branch)
+- [ ] `decisions.md` has at least one entry per iteration that took an action
+- [ ] `deferred.md` is listed in the final report with count matching state.deferred
+- [ ] The project's test command and `grace lint --path . --assertions current` exit 0 on the final commit (verification: attach exit codes)
+- [ ] A final `$grace-reviewer` pass ran; its findings (with severities) are in the dashboard and journaled (`class=review`)
+- [ ] User has been announced the final dashboard with next-action suggestion

--- a/plugins/grace/skills/grace/grace-ask-human/SKILL.md
+++ b/plugins/grace/skills/grace/grace-ask-human/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: grace-ask-human
+description: "Short Telegram escalation during autonomous sessions. Use ONLY from inside grace-afk, when a one-way-door decision must be confirmed by a human. Builds a message of 10 lines or fewer, sends it via grace afk ask, and polls grace afk check with exponential backoff. Blocks until a reply, a timeout, or session expiry."
+---
+
+Send a Telegram escalation to the human with a hard short format, then poll for the reply.
+
+This skill is **a thin wrapper around `grace afk ask` and `grace afk check`**. It exists to
+enforce message discipline — without it, LLMs send walls of text over Telegram which the user
+cannot act on from a phone.
+
+## Preconditions
+
+- You are inside an active `grace-afk` session (checked by `grace afk tick` returning 0).
+- Telegram config is available through any of: `$GRACE_AFK_CONFIG` env var, `<project>/.grace-afk.json`, or global `~/.grace/afk.json` (checked in that priority).
+- You have a decision that qualifies as `one-way-door-escalated` (see `grace-afk#Autonomy-Matrix`).
+  **If the decision is reversible, do NOT escalate** — act and journal.
+
+## Message Format (hard)
+
+The CLI generates this from your input to `grace afk ask`. You pass:
+
+- `--title "<5-10 word decision title>"`
+- `--context "<one sentence — the situation>"`
+- `--options "A:<1 line>;B:<1 line>;C:<1 line>"` (2-5 options). Use `;` as a separator — it is safer than `|` across Windows shells.
+- `--details "A|pros|cons|opportunities|risks;B|..."` (optional). When provided, the message gets a `[📖 Details]` button. On tap the CLI sends a SWOT breakdown (Pros / Cons / Opportunities / Risks) as a follow-up message without cancelling the ask — the user reads it, goes back to the first message, then picks A/B/C/PROCEED/DEFER/STOP.
+- `--wait <seconds>` (optional, default 0). When >0, the CLI blocks and polls `getUpdates` every 2 seconds. On an inline-button tap it calls `answerCallbackQuery` immediately so the spinner stops within ~2s (inside Telegram's 15-second callback timeout window), strips the keyboard on the original message, and returns the classified answer as JSON. Without `--wait`, the agent must call `grace afk check` separately to pick up and ack the reply — on Telegram that means the user's spinner shimmers until the next check.
+- `--mypick <letter>` — the option you'd pick if forced
+- `--confidence <0-100>` — your percent confidence in that pick
+
+Total message ≤10 lines. No multi-paragraph explanations. If you need paragraphs, the
+question is not shaped for Telegram — simplify or defer.
+
+## Process
+
+### Step 1. Confirm this is escalation-worthy
+
+Answer these in your working notes before sending:
+- Is this decision irreversible (cannot be undone by `git reset --hard afk-baseline-<ts>`)?
+- Is there a default that would be safe on timeout? (If yes, include it as an option.)
+- Have you already escalated the maximum times this session? (CLI will refuse if so.)
+
+If any answer is no — use `grace afk defer` instead.
+
+### Step 2. Send
+
+```
+grace afk ask \
+  --path . \
+  --title "Merge afk branch into main" \
+  --context "Plan step-12 complete, 14 commits, all gates green; ready to merge" \
+  --options "A:merge to main;B:open PR for review;C:leave as afk branch" \
+  --mypick B \
+  --confidence 80
+```
+
+CLI returns JSON: `{ correlationId, messageId, sessionId }`. Store these — both are needed to poll.
+
+### Step 3. Poll with backoff
+
+Wait the backoff interval, then call:
+
+```
+grace afk check --path . --correlation <id> --messageid <msgId> --offset <lastOffset>
+```
+
+Result shapes:
+- `{ status: "pending" }` — no reply yet
+- `{ status: "answered", verb: "A|B|C|D|E|PROCEED|STOP|EVOLVE|DEFER", raw, nextOffset }` — done
+- `{ status: "unrecognized", verb: "UNKNOWN", raw, nextOffset }` — user wrote free-form text
+
+Backoff schedule:
+1. First check: **10 minutes** after send
+2. Then: **30 minutes** after the first check
+3. Then: **60 minutes**
+4. Then: **120 minutes** (final check)
+
+Total wait ≤ 220 minutes. No reply after that → fall through to Step 4.
+
+Between poll checks, you should NOT be idle — continue the /afk loop on independent steps.
+Come back to this correlation id whenever the backoff has elapsed.
+
+### Step 4. Fall-through if no reply
+
+- If any option has "default on timeout" semantics (e.g. `ROLLBACK`), execute it; journal
+  `class=one-way-door-escalated` with `outcome=default-on-timeout`.
+- Otherwise `grace afk defer --question "<title>" --contextLine "<context>"` and continue.
+
+### Step 5. On answer
+
+- `A/B/C/D/E` → act per that option, journal with the chosen option.
+- `PROCEED` → act per your `--mypick`, journal with confidence noted.
+- `STOP` → `grace afk stop --reason "user STOP via telegram"`; exit the loop.
+- `EVOLVE` → defer (grace-evolve not yet available); journal with that note.
+- `DEFER` → `grace afk defer`; continue with next step.
+- `UNKNOWN` (free-form) → journal the raw text under `outcome=manual-interpretation-required`,
+  then defer (do not try to interpret complex free-form replies autonomously).
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Just this once, let me send a longer message with full context" | The user is on a phone at 02:00. Long context does not help them, it delays the reply. Simplify or defer. |
+| "I'll send one ask and act immediately, don't need to poll" | That defeats the purpose. The ask is a BLOCKING gate for this decision path. Do work on other steps while polling. |
+| "The user hasn't replied, I'll re-send to remind" | Spamming Telegram is why max-escalations exists. Stick to the backoff schedule. |
+| "I can interpret 'sounds good' as PROCEED" | Only classify replies the CLI recognizes. 'sounds good' is UNKNOWN → defer to clear reply on return. |
+| "This is borderline one-way; I'll ask just to be safe" | Asks are expensive (phone ping, user interruption). Borderline → reversible → act. |
+
+## Red Flags
+
+- You have sent >3 Telegram escalations in this session (CLI will now refuse).
+- Your message is >10 lines or contains paragraphs.
+- You are waiting synchronously on a single ask instead of continuing other work.
+- You are interpreting free-form replies as if they were one of the enum verbs.
+- You are about to ask a question that is not actually one-way-door.
+
+## When NOT to Use
+
+- Outside of a `grace-afk` session (the CLI will refuse, but you should not even try).
+- For questions that are NOT decisions (e.g. "what's the weather?").
+- For decisions that have a clear reversible path — act instead.
+- When the Telegram config is missing — use `grace afk defer` directly.
+
+## Verification
+
+Before returning control to `grace-afk`:
+
+- [ ] Message sent successfully (`grace afk ask` returned ok, correlationId noted)
+- [ ] Reply received OR backoff exhausted OR session ended (verification: `grace afk check` result or state.json)
+- [ ] Journal entry written with class `one-way-door-escalated` and the chosen verb
+- [ ] Session counter `escalations` incremented (verification: `cat state.json | jq .escalations`)
+- [ ] If STOP received: `grace afk stop` invoked and report emitted

--- a/plugins/grace/skills/grace/grace-init/assets/grace-afk.json.template
+++ b/plugins/grace/skills/grace/grace-init/assets/grace-afk.json.template
@@ -1,0 +1,11 @@
+{
+  "_comment": "Config for the grace-afk autonomous harness. MUST be gitignored — contains secrets.",
+  "_docs": "https://github.com/osovv/grace-marketplace#grace-afk",
+  "telegram": {
+    "botToken": "$TELEGRAM_BOT_TOKEN",
+    "chatId": "$TELEGRAM_CHAT_ID"
+  },
+  "autoStop": {
+    "maxEscalationsPerSession": 3
+  }
+}

--- a/skills/grace/grace-afk/SKILL.md
+++ b/skills/grace/grace-afk/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: grace-afk
+description: "Autonomous work mode for when the user is AFK. Use when the user types `/afk [hours] [budget%] [--checkpoint <min>]` or asks the agent to keep working on its own. The CLI enforces the time budget — the agent polls `grace afk tick` between steps and stops when the CLI says so. One-way-door decisions are escalated to Telegram via `grace afk ask`; everything else is acted on, deferred, or rolled back per the autonomy matrix."
+---
+
+Run the /afk harness: keep working through the active GRACE 4 change plan
+(`.grace/changes/active/C-*/plan.xml`) on an isolated branch,
+making decisions from the user on their behalf within declared boundaries, until the CLI-enforced
+budget expires or the user sends STOP via Telegram.
+
+<EXTREMELY-IMPORTANT>
+You are NOT the budget tracker. The CLI is.
+
+Between every logical step you MUST run `grace afk tick --path <project-root>`. If it exits
+non-zero, your session is over — commit the in-progress work (if any), run `grace afk report`,
+and stop. Do NOT try to estimate remaining budget yourself and keep going. The hard gate is
+the CLI exit code.
+</EXTREMELY-IMPORTANT>
+
+## Prerequisites
+
+- Project is GRACE 4-managed (`.grace/` exists). If it is still on the GRACE 3 `docs/*.xml` layout, run `$grace-migrate` first; if it has no GRACE at all, run `$grace-init` first.
+- `@osovv/grace-cli` installed (the binary `grace` is on PATH).
+- Telegram config resolved by lookup priority: `$GRACE_AFK_CONFIG` env var, then `<project>/.grace-afk.json`, then `~/.grace/afk.json` (global user-level fallback). Configure one of these if `grace-ask-human` escalations are expected — otherwise one-way-door decisions fall back to `grace afk defer`.
+
+## Command Surface (CLI)
+
+Every subcommand below takes `--path <project-root>` (defaults to `.`).
+
+| Command | Purpose |
+|---|---|
+| `grace afk start <hours> [<budget%>] [--checkpoint <min>]` | Initialize a session; writes `docs/afk-sessions/<id>/state.json` with `expiresAt`. |
+| `grace afk tick` | CLI-side active-session check. Non-zero exit = session over. |
+| `grace afk ask --title ... --context ... --options "A:...;B:..." --mypick B --confidence 60 [--details "A\|pros\|cons\|opps\|risks;B\|..."] [--wait 120]` | Send a Telegram escalation; returns `{correlationId, messageId}`. Use `;` as a separator (safer across Windows shells) or `\|`. `--details` (5-field SWOT per option) adds a `[📖 Details]` button that sends a follow-up breakdown without cancelling the ask. `--wait N` blocks up to N seconds polling, ack-ing inline-button taps within ~2s so the user's Telegram spinner stops immediately. |
+| `grace afk check --correlation <id> --messageid <n> [--offset <o>]` | Poll Telegram; returns `{status, verb, raw, nextOffset}`. |
+| `grace afk journal --class <c> --title ... --rationale ... --outcome ...` | Append to `decisions.md`. |
+| `grace afk defer --question ... --contextLine ...` | Append to `deferred.md`. |
+| `grace afk increment <commits\|escalations\|deferred>` | Update session counters after an action. |
+| `grace afk report` | Print the return dashboard and mark session completed. |
+| `grace afk stop --reason "..."` | Manual stop (e.g. when user sends `STOP` in Telegram). |
+
+Exit codes from `tick`:
+- `0` — session active, continue
+- `42` — `BUDGET_EXHAUSTED` (time expired)
+- `43` — no active session
+- `44` — session was stopped
+- `45` — Telegram sendMessage failed (only from `ask`)
+- `46` — grace-afk config missing at env var, project root, and `~/.grace/afk.json` (only from `ask` / `check`)
+- `2`  — bad arguments (unknown --class, missing --context, etc.)
+
+### Windows-specific note on exit codes
+
+On Windows, if the agent invokes `bun run ./src/grace.ts afk tick` via a shell
+wrapper, `bun run` can squash custom exit codes into `1` or `255`. Two defences:
+
+1. Prefer invoking `bun <file>` directly (no `run` verb) when spawning subprocesses
+   from the harness.
+2. Also parse the first line of stderr as a fallback — `tick` prints the reason
+   before exiting (`Budget exhausted`, `no active session`, `stopped`). If the
+   numeric code is squashed to 1/255, the stderr line still disambiguates.
+
+The agent must NOT assume a non-zero exit is always `BUDGET_EXHAUSTED`. Check the
+value first; if it is 1 or 255, read stderr to disambiguate before acting.
+
+## Startup Protocol
+
+1. Parse the user's `/afk [hours] [budget%] [--checkpoint <m>]` invocation. Defaults: `hours=2`,
+   `budget%=default`, `checkpoint=30`.
+2. **Create isolation:**
+   - `git tag afk-baseline-<timestamp>`
+   - `git checkout -b afk-<timestamp>` from the current branch tip
+3. **Start session:** `grace afk start <hours> [<budget%>] [--checkpoint <min>] --path .`
+4. **Announce to user** (single line): session id, expiresAt, first step to be worked.
+5. Enter the loop.
+
+## The Loop
+
+Every iteration:
+
+1. **Tick.** Run `grace afk tick --path .`. Non-zero exit → jump to "End of session" below.
+2. **Pick next task.** Read the active change bundle in `.grace/changes/active/C-*/`: take the
+   approved `plan.xml`, find the first pending `T-NNN` task in `<ImplementationPlan>` whose
+   `<DependsOn>` tasks are all done. If none, jump to "End of session". If several bundles are
+   active, work them one at a time, in `C-*` id order.
+3. **Route via autonomy matrix** (see below). Act / defer / escalate.
+4. **If acting:** execute the task (invoke the appropriate `grace-*` skill — usually
+   `grace-execute` for the next plan task, or `grace-fix` for a bug). Commit the result with the
+   project's usual message convention, referencing the change id and task id. Run `grace afk increment commits`.
+5. **Record decision.** `grace afk journal --class <c> --title ... --rationale ... --outcome ...`.
+6. **Verify gates.** Run the project's test command and `grace lint --path . --assertions current`.
+   The green/yellow/red gate logic applies even in single-task mode:
+   - green → next iteration
+   - yellow → rollback the step (`git reset --hard HEAD~1` on your afk branch ONLY), journal the rollback,
+     next iteration
+   - red → escalate to Telegram if budget allows; else defer and stop
+7. **Checkpoint check.** If `checkpointMinutes` have passed since start or last checkpoint, run
+   a summary (tick, lint, journal entry `class=checkpoint`).
+
+## Autonomy Matrix
+
+| Class | Trigger | Action |
+|---|---|---|
+| `reversible-act` | Obvious implementation step; well-defined contract; single credible approach | **Act** — invoke `grace-execute` or `grace-fix`; journal; continue. |
+| `uncertain-deferred` | Multiple credible approaches with different tradeoffs, no obvious winner | **Defer** to `deferred.md` with a note on the competing approaches. |
+| `one-way-door-escalated` | Irreversible or main-branch-affecting: push to main, force push, drop DB, deploy, external API side-effects, changing a public MODULE_CONTRACT | **`grace afk ask`** via Telegram; poll `grace afk check` with backoff 10 / 30 / 60 / 120 min. |
+| `one-way-door-deferred` | Same as above but Telegram unavailable OR max escalations already sent | **Defer** and move to next step. |
+| `scope-creep-deferred` | The step's description would pull in edits outside the declared write scope | **Always defer**, never act. |
+| `threshold-yellow-rollback` | Tests / lint / graph consistency between green and red | Rollback + next step. |
+| `threshold-red-escalated` | Hard fail on any gate | Telegram ask with options `ROLLBACK / STOP`; default to ROLLBACK on timeout. |
+| `checkpoint` | Periodic summary | Journal entry; never an action. |
+
+Rule (anti-Goodhart): "one-way door" is a **behavioural test**, not a feeling. If a single
+`git reset --hard afk-baseline-<ts>` cannot fully undo the action, it is one-way. If the action
+is file edits on the `afk-*` branch only — it is reversible, act freely.
+
+## Telegram Escalation Format
+
+Delegated to `$grace-ask-human`. Key rules:
+- Short (≤10 lines). No prose summaries.
+- A/B/C options, 1 line each.
+- State your current pick + confidence.
+- User replies with one of: `A B C D E PROCEED STOP EVOLVE DEFER` (case-insensitive, any position).
+- Polling: 10min → 30min → 60min → 120min. No reply after 120min → fall through: if the ask was
+  `uncertain` → defer; if `one-way-door` with no default → stop the session; if `threshold-red`
+  with ROLLBACK as option → rollback.
+
+Hard cap: **3 escalations per session** (enforced by CLI via `--autoStop.maxEscalationsPerSession`).
+Past that, you must defer remaining one-way-door decisions.
+
+## Idle-fill: review while awaiting a reply
+
+While a `grace afk ask` is outstanding and you are polling `grace afk check` (the 10/30/60/120 min
+backoff is long idle time), do NOT sit idle — spend it on a **read-only** `$grace-reviewer` pass over
+the work done so far on the `afk-*` branch (5 axes + `grace lint --path .`). Queue findings in the
+journal (`grace afk journal --class review ...`); do not block on them.
+
+Guardrails:
+- **Read-only by default.** Apply only clearly-reversible fixes that are in-scope AND unrelated to the
+  question under escalation. Anything touching the escalated decision waits for the answer.
+- **Interruptible.** The moment `grace afk check` returns a verb, drop the review immediately and act
+  on the reply. Never make the user wait on a review.
+- Keep running `grace afk tick` between review chunks — the budget clock keeps running during the wait.
+
+## STOP handling
+
+If you see `grace afk check` return `{verb: "STOP"}`, immediately:
+1. Commit any in-progress work (with message `grace(afk): checkpoint before STOP`).
+2. Run `grace afk stop --reason "user STOP via telegram"`.
+3. Run `grace afk report`.
+4. Exit the loop. Do not take further actions.
+
+## End of Session
+
+Triggered by: `tick` non-zero, user STOP, plan exhausted, hard block (e.g. CLI failure).
+
+1. Ensure working tree is committed (or stashed with a descriptive name).
+2. **Final review.** Run a `$grace-reviewer` integrity pass over the whole `afk-*` branch (all 5 axes)
+   plus `grace lint --path .`. Fold the findings (with severities) into the return dashboard so the
+   human sees the QUALITY of the work, not just the list of commits. Journal it
+   (`grace afk journal --class review ...`). Read-only — do NOT auto-fix at end of session; let the
+   human decide what to act on.
+3. Run `grace afk report --path .` (this marks the session completed).
+4. Announce to the user: branch name, session id, deferred count, commits count, **review summary**,
+   next suggested action (usually: review `deferred.md` + the review findings, then merge `afk-<ts>`
+   into the target feature branch).
+5. Do not delete the `afk-<ts>` branch — leave it for human review.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I can estimate budget better than the CLI" | You can't. LLM math on token consumption is unreliable and biased toward continuing. The CLI has the real clock. |
+| "This one decision is borderline one-way, I'll just act" | Borderline = defer. Over a long session, "just act" on every borderline becomes the majority of decisions and you end up with un-reviewable diffs. |
+| "Telegram escalation is overkill for this small choice" | If it is small, it is not a one-way door — act, do not escalate. If it is one-way, it is not small. |
+| "The reviewer will catch anything bad" | There is no reviewer. You are alone. The human will see only the final diff + journal. Be conservative. |
+| "I'll skip the journal entry for trivial steps" | The journal is how the human reconstructs what you did. Trivial steps are the ones most likely to be questioned on return. |
+| "I should check budget every minute just in case" | Every tick burns API cost. Call tick between logical steps, not inside tight loops. |
+| "The plan task is too vague, I'll reinterpret it" | Vague plan task = `scope-creep-deferred`. Do not reinterpret; defer and let the human clarify. |
+
+## Red Flags
+
+- You are about to edit a file outside the declared write scope of the current plan step.
+- You are considering `git push` or anything that touches `main` / `master`.
+- You are about to change a MODULE_CONTRACT without a Telegram ask.
+- You have not run `grace afk tick` in the last 15 minutes.
+- You have escalated more than 3 times in one session.
+- You are editing `docs/afk-sessions/<id>/state.json` by hand (never do this — use CLI commands).
+
+## When NOT to Use
+
+- The user is present and actively iterating. `/afk` is for unattended work.
+- The plan is unclear or missing. Run `$grace-plan` first.
+- There are no pending `T-NNN` tasks in the active change plan. Nothing to do.
+- Verification coverage is skeletal. Without `V-M-*` entries, the "verify gates" step has no teeth.
+- Less than 30 minutes of intended autonomy — just keep working in the foreground instead.
+
+## Verification
+
+Before exiting, confirm:
+
+- [ ] Session state shows `status=completed` or `status=stopped` (verification: `cat docs/afk-sessions/<id>/state.json | jq .status`)
+- [ ] All in-progress code committed on `afk-<ts>` branch (verification: `git status` clean on that branch)
+- [ ] `decisions.md` has at least one entry per iteration that took an action
+- [ ] `deferred.md` is listed in the final report with count matching state.deferred
+- [ ] The project's test command and `grace lint --path . --assertions current` exit 0 on the final commit (verification: attach exit codes)
+- [ ] A final `$grace-reviewer` pass ran; its findings (with severities) are in the dashboard and journaled (`class=review`)
+- [ ] User has been announced the final dashboard with next-action suggestion

--- a/skills/grace/grace-ask-human/SKILL.md
+++ b/skills/grace/grace-ask-human/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: grace-ask-human
+description: "Short Telegram escalation during autonomous sessions. Use ONLY from inside grace-afk, when a one-way-door decision must be confirmed by a human. Builds a message of 10 lines or fewer, sends it via grace afk ask, and polls grace afk check with exponential backoff. Blocks until a reply, a timeout, or session expiry."
+---
+
+Send a Telegram escalation to the human with a hard short format, then poll for the reply.
+
+This skill is **a thin wrapper around `grace afk ask` and `grace afk check`**. It exists to
+enforce message discipline — without it, LLMs send walls of text over Telegram which the user
+cannot act on from a phone.
+
+## Preconditions
+
+- You are inside an active `grace-afk` session (checked by `grace afk tick` returning 0).
+- Telegram config is available through any of: `$GRACE_AFK_CONFIG` env var, `<project>/.grace-afk.json`, or global `~/.grace/afk.json` (checked in that priority).
+- You have a decision that qualifies as `one-way-door-escalated` (see `grace-afk#Autonomy-Matrix`).
+  **If the decision is reversible, do NOT escalate** — act and journal.
+
+## Message Format (hard)
+
+The CLI generates this from your input to `grace afk ask`. You pass:
+
+- `--title "<5-10 word decision title>"`
+- `--context "<one sentence — the situation>"`
+- `--options "A:<1 line>;B:<1 line>;C:<1 line>"` (2-5 options). Use `;` as a separator — it is safer than `|` across Windows shells.
+- `--details "A|pros|cons|opportunities|risks;B|..."` (optional). When provided, the message gets a `[📖 Details]` button. On tap the CLI sends a SWOT breakdown (Pros / Cons / Opportunities / Risks) as a follow-up message without cancelling the ask — the user reads it, goes back to the first message, then picks A/B/C/PROCEED/DEFER/STOP.
+- `--wait <seconds>` (optional, default 0). When >0, the CLI blocks and polls `getUpdates` every 2 seconds. On an inline-button tap it calls `answerCallbackQuery` immediately so the spinner stops within ~2s (inside Telegram's 15-second callback timeout window), strips the keyboard on the original message, and returns the classified answer as JSON. Without `--wait`, the agent must call `grace afk check` separately to pick up and ack the reply — on Telegram that means the user's spinner shimmers until the next check.
+- `--mypick <letter>` — the option you'd pick if forced
+- `--confidence <0-100>` — your percent confidence in that pick
+
+Total message ≤10 lines. No multi-paragraph explanations. If you need paragraphs, the
+question is not shaped for Telegram — simplify or defer.
+
+## Process
+
+### Step 1. Confirm this is escalation-worthy
+
+Answer these in your working notes before sending:
+- Is this decision irreversible (cannot be undone by `git reset --hard afk-baseline-<ts>`)?
+- Is there a default that would be safe on timeout? (If yes, include it as an option.)
+- Have you already escalated the maximum times this session? (CLI will refuse if so.)
+
+If any answer is no — use `grace afk defer` instead.
+
+### Step 2. Send
+
+```
+grace afk ask \
+  --path . \
+  --title "Merge afk branch into main" \
+  --context "Plan step-12 complete, 14 commits, all gates green; ready to merge" \
+  --options "A:merge to main;B:open PR for review;C:leave as afk branch" \
+  --mypick B \
+  --confidence 80
+```
+
+CLI returns JSON: `{ correlationId, messageId, sessionId }`. Store these — both are needed to poll.
+
+### Step 3. Poll with backoff
+
+Wait the backoff interval, then call:
+
+```
+grace afk check --path . --correlation <id> --messageid <msgId> --offset <lastOffset>
+```
+
+Result shapes:
+- `{ status: "pending" }` — no reply yet
+- `{ status: "answered", verb: "A|B|C|D|E|PROCEED|STOP|EVOLVE|DEFER", raw, nextOffset }` — done
+- `{ status: "unrecognized", verb: "UNKNOWN", raw, nextOffset }` — user wrote free-form text
+
+Backoff schedule:
+1. First check: **10 minutes** after send
+2. Then: **30 minutes** after the first check
+3. Then: **60 minutes**
+4. Then: **120 minutes** (final check)
+
+Total wait ≤ 220 minutes. No reply after that → fall through to Step 4.
+
+Between poll checks, you should NOT be idle — continue the /afk loop on independent steps.
+Come back to this correlation id whenever the backoff has elapsed.
+
+### Step 4. Fall-through if no reply
+
+- If any option has "default on timeout" semantics (e.g. `ROLLBACK`), execute it; journal
+  `class=one-way-door-escalated` with `outcome=default-on-timeout`.
+- Otherwise `grace afk defer --question "<title>" --contextLine "<context>"` and continue.
+
+### Step 5. On answer
+
+- `A/B/C/D/E` → act per that option, journal with the chosen option.
+- `PROCEED` → act per your `--mypick`, journal with confidence noted.
+- `STOP` → `grace afk stop --reason "user STOP via telegram"`; exit the loop.
+- `EVOLVE` → defer (grace-evolve not yet available); journal with that note.
+- `DEFER` → `grace afk defer`; continue with next step.
+- `UNKNOWN` (free-form) → journal the raw text under `outcome=manual-interpretation-required`,
+  then defer (do not try to interpret complex free-form replies autonomously).
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Just this once, let me send a longer message with full context" | The user is on a phone at 02:00. Long context does not help them, it delays the reply. Simplify or defer. |
+| "I'll send one ask and act immediately, don't need to poll" | That defeats the purpose. The ask is a BLOCKING gate for this decision path. Do work on other steps while polling. |
+| "The user hasn't replied, I'll re-send to remind" | Spamming Telegram is why max-escalations exists. Stick to the backoff schedule. |
+| "I can interpret 'sounds good' as PROCEED" | Only classify replies the CLI recognizes. 'sounds good' is UNKNOWN → defer to clear reply on return. |
+| "This is borderline one-way; I'll ask just to be safe" | Asks are expensive (phone ping, user interruption). Borderline → reversible → act. |
+
+## Red Flags
+
+- You have sent >3 Telegram escalations in this session (CLI will now refuse).
+- Your message is >10 lines or contains paragraphs.
+- You are waiting synchronously on a single ask instead of continuing other work.
+- You are interpreting free-form replies as if they were one of the enum verbs.
+- You are about to ask a question that is not actually one-way-door.
+
+## When NOT to Use
+
+- Outside of a `grace-afk` session (the CLI will refuse, but you should not even try).
+- For questions that are NOT decisions (e.g. "what's the weather?").
+- For decisions that have a clear reversible path — act instead.
+- When the Telegram config is missing — use `grace afk defer` directly.
+
+## Verification
+
+Before returning control to `grace-afk`:
+
+- [ ] Message sent successfully (`grace afk ask` returned ok, correlationId noted)
+- [ ] Reply received OR backoff exhausted OR session ended (verification: `grace afk check` result or state.json)
+- [ ] Journal entry written with class `one-way-door-escalated` and the chosen verb
+- [ ] Session counter `escalations` incremented (verification: `cat state.json | jq .escalations`)
+- [ ] If STOP received: `grace afk stop` invoked and report emitted

--- a/skills/grace/grace-init/assets/grace-afk.json.template
+++ b/skills/grace/grace-init/assets/grace-afk.json.template
@@ -1,0 +1,11 @@
+{
+  "_comment": "Config for the grace-afk autonomous harness. MUST be gitignored — contains secrets.",
+  "_docs": "https://github.com/osovv/grace-marketplace#grace-afk",
+  "telegram": {
+    "botToken": "$TELEGRAM_BOT_TOKEN",
+    "chatId": "$TELEGRAM_CHAT_ID"
+  },
+  "autoStop": {
+    "maxEscalationsPerSession": 3
+  }
+}

--- a/src/afk-cli.test.ts
+++ b/src/afk-cli.test.ts
@@ -1,0 +1,487 @@
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
+
+// Each runCli invocation spawns `bun` (~500ms cold-start on Windows) + mkdtemp for an isolated
+// $HOME. Tests that chain 3+ invocations approach the default 5s ceiling on slow machines.
+// Bump the per-test ceiling so the suite stays deterministic under CI/Windows load.
+setDefaultTimeout(15000);
+
+function tmpProject() {
+  return mkdtempSync(path.join(os.tmpdir(), "grace-afk-cli-"));
+}
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+const CLI_ENTRY = path.join(REPO_ROOT, "src", "grace.ts");
+
+// On Windows, `bun` on PATH is typically a `.cmd` shim installed via npm. Node's
+// auto-detection for .cmd executables in `spawnSync` is known to return status=null on some
+// installations (reported by the Gemini reviewer on the same branch — their local run got
+// 12 CLI tests exiting with -1 while ours got 13/13 because of Node version differences).
+//
+// Defensive fix: resolve the binary name explicitly by platform.
+//   - win32  -> `bun.cmd` (the npm-shim wrapper that cmd.exe can locate on PATH without shell)
+//   - other  -> `bun`
+//
+// We deliberately do NOT use `shell: true` — that would force cmd.exe to re-parse our args,
+// break string quoting for values with spaces (observed regression: "what next?" became
+// "what" + "next?"), and introduce injection surface for user-controlled test inputs. Naming
+// the binary directly avoids the shell entirely and lets Node.js do its normal arg-escaping.
+const BUN_BIN = process.platform === "win32" ? "bun.cmd" : "bun";
+
+function runCli(cwd: string, args: string[], opts: { home?: string } = {}) {
+  // Invoke `bun <file>` rather than `bun run <file>`: `bun run` wraps the child and on Windows
+  // does not reliably propagate custom exit codes above a single-digit range (observed: any
+  // `process.exitCode = 46` became 255 at the parent).
+  //
+  // Isolate $HOME / $USERPROFILE: since 4.0.0-beta.2 afk config also falls back to a global
+  // ~/.grace/afk.json. If tests inherited the real home, presence of a dev machine's global
+  // config would flip EXIT_CONFIG_MISSING tests. Every runCli call gets a throwaway home,
+  // making tests deterministic regardless of local dev setup.
+  const home = opts.home ?? mkdtempSync(path.join(os.tmpdir(), "grace-afk-cli-home-"));
+  const result = spawnSync(BUN_BIN, [CLI_ENTRY, "afk", ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      GRACE_AFK_CONFIG: "",
+    },
+  });
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("grace afk CLI", () => {
+  it("start creates state and tick reports remaining time", () => {
+    const root = tmpProject();
+    const start = runCli(root, ["start", "1", "--path", root]);
+    expect(start.code).toBe(0);
+    expect(start.stdout).toContain("Started /afk session");
+
+    const tick = runCli(root, ["tick", "--path", root]);
+    expect(tick.code).toBe(0);
+    expect(tick.stdout).toMatch(/remaining=\d+/);
+    expect(tick.stdout).toContain("status=active");
+  });
+
+  it("tick returns EXIT_BUDGET_EXHAUSTED once session expired", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+
+    // Force-expire by editing expiresAt to the past.
+    const docsDir = path.join(root, "docs", "afk-sessions");
+    const sessionDirs = require("node:fs").readdirSync(docsDir);
+    const statePath = path.join(docsDir, sessionDirs[0], "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    state.expiresAt = new Date(Date.now() - 60_000).toISOString();
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+    const tick = runCli(root, ["tick", "--path", root]);
+    expect(tick.code).toBe(42); // EXIT_BUDGET_EXHAUSTED
+    expect(tick.stderr).toContain("Budget exhausted");
+  });
+
+  it("tick returns EXIT_NO_SESSION when no session has been started", () => {
+    const root = tmpProject();
+    const tick = runCli(root, ["tick", "--path", root]);
+    expect(tick.code).toBe(43); // EXIT_NO_SESSION
+    expect(tick.stderr).toContain("no active session");
+  });
+
+  it("journal and defer append to files and increment counters", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "2", "--path", root]);
+
+    const journal = runCli(root, [
+      "journal",
+      "--path",
+      root,
+      "--class",
+      "reversible-act",
+      "--title",
+      "Test",
+      "--rationale",
+      "because",
+      "--outcome",
+      "ok",
+    ]);
+    expect(journal.code).toBe(0);
+
+    const defer = runCli(root, [
+      "defer",
+      "--path",
+      root,
+      "--question",
+      "what next?",
+      "--contextLine",
+      "step-1",
+    ]);
+    expect(defer.code).toBe(0);
+
+    const docsDir = path.join(root, "docs", "afk-sessions");
+    const sessionId = require("node:fs").readdirSync(docsDir)[0];
+    const decisionsPath = path.join(docsDir, sessionId, "decisions.md");
+    const deferredPath = path.join(docsDir, sessionId, "deferred.md");
+    expect(existsSync(decisionsPath)).toBe(true);
+    expect(existsSync(deferredPath)).toBe(true);
+    expect(readFileSync(decisionsPath, "utf8")).toContain("reversible-act");
+    expect(readFileSync(deferredPath, "utf8")).toContain("what next?");
+
+    const statePath = path.join(docsDir, sessionId, "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(state.deferred).toBe(1);
+  });
+
+  it("stop marks session stopped and subsequent tick exits with EXIT_SESSION_STOPPED", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "2", "--path", root]);
+    const stop = runCli(root, ["stop", "--path", root, "--reason", "test"]);
+    expect(stop.code).toBe(0);
+
+    const tick = runCli(root, ["tick", "--path", root]);
+    expect(tick.code).toBe(44); // EXIT_SESSION_STOPPED
+    expect(tick.stderr).toContain("stopped");
+  });
+
+  it("report shows summary and marks completed", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+    const report = runCli(root, ["report", "--path", root]);
+    expect(report.code).toBe(0);
+    expect(report.stdout).toContain("report");
+    expect(report.stdout).toContain("Status:");
+
+    // After report, session is completed; tick should exit with no-active-session.
+    const tick = runCli(root, ["tick", "--path", root]);
+    expect(tick.code).toBe(43);
+  });
+});
+
+describe("projectNameFromPath (via ask smoke)", () => {
+  it("converts kebab-case basename to Title Case", async () => {
+    const { projectNameFromPath } = await import("./grace-afk");
+    expect(projectNameFromPath("/tmp/grace-marketplace-2")).toBe("Grace Marketplace 2");
+    expect(projectNameFromPath("D:/Python/GRACE_2/grace-marketplace-2")).toBe("Grace Marketplace 2");
+    expect(projectNameFromPath("/foo/bar_baz-quux")).toBe("Bar Baz Quux");
+    expect(projectNameFromPath(".")).not.toBe("");
+  });
+});
+
+describe("buildAskMessage", () => {
+  it("uses the project name as the visible first-line prefix", async () => {
+    const { buildAskMessage } = await import("./grace-afk");
+    const text = buildAskMessage({
+      correlationId: "abc123",
+      sessionId: "sess-1",
+      projectName: "Grace Marketplace 2",
+      title: "pick one",
+      context: "situation",
+      options: ["A:x"],
+      myPick: "A",
+      confidence: "80",
+    });
+    const firstLine = text.split("\n")[0];
+    expect(firstLine).toContain("Grace Marketplace 2");
+    expect(firstLine).toContain("abc123");
+  });
+});
+
+describe("buildDoneContext", () => {
+  it("formats elapsed time + counters + usage on one line", async () => {
+    const { buildDoneContext } = await import("./grace-afk");
+    const start = "2026-04-19T04:00:00.000Z";
+    const now = new Date("2026-04-19T05:17:00.000Z"); // +1h17m
+    const line = buildDoneContext({
+      sessionStartIso: start,
+      now,
+      commits: 3,
+      escalations: 1,
+      deferred: 2,
+      usageLine: "5h 7% · 7d 21%",
+    });
+    expect(line).toContain("1h 17m");
+    expect(line).toContain("3 commits");
+    expect(line).toContain("1 escalations");
+    expect(line).toContain("2 deferred");
+    expect(line).toContain("5h 7%");
+  });
+
+  it("omits the usage block when usageLine is null", async () => {
+    const { buildDoneContext } = await import("./grace-afk");
+    const line = buildDoneContext({
+      sessionStartIso: "2026-04-19T04:00:00.000Z",
+      now: new Date("2026-04-19T04:05:00.000Z"),
+      commits: 0,
+      escalations: 0,
+      deferred: 0,
+      usageLine: null,
+    });
+    expect(line).toContain("5m");
+    expect(line).not.toContain("5h");
+  });
+});
+
+describe("parseDetailsArg + buildDetailsMessage + buildAskKeyboard(hasDetails)", () => {
+  it("parses the 5-field SWOT details arg", async () => {
+    const { parseDetailsArg } = await import("./grace-afk");
+    const map = parseDetailsArg("A|pros-a|cons-a|opps-a|risks-a;B|pros-b|cons-b|opps-b|risks-b");
+    expect(map.size).toBe(2);
+    expect(map.get("A")?.pros).toBe("pros-a");
+    expect(map.get("B")?.risks).toBe("risks-b");
+    expect(map.get("A")?.opportunities).toBe("opps-a");
+  });
+
+  it("renders the SWOT message with project name, correlation id, and all four sections per option", async () => {
+    const { buildDetailsMessage, parseDetailsArg } = await import("./grace-afk");
+    const map = parseDetailsArg("A|p|c|o|r;B|p2|c2|o2|r2");
+    const text = buildDetailsMessage({
+      projectName: "Grace Marketplace 2",
+      correlationId: "abc123",
+      options: ["A:first", "B:second"],
+      details: map,
+    });
+    expect(text).toContain("[Grace Marketplace 2] Decision details abc123");
+    // The "A:" letter prefix from the raw option is stripped so we don't render "A — A:first".
+    expect(text).toContain("A — first");
+    expect(text).toContain("B — second");
+    expect(text).not.toContain("A — A:first");
+    expect(text).toContain("Pros:          p");
+    expect(text).toContain("Cons:");
+    expect(text).toContain("Opportunities:");
+    expect(text).toContain("Risks:");
+  });
+
+  it("adds the [Details] row to the keyboard only when hasDetails=true", async () => {
+    const { buildAskKeyboard } = await import("./grace-afk");
+    const without = buildAskKeyboard("abc", ["A:x", "B:y"], false);
+    expect(without).toHaveLength(2);
+    const withDetails = buildAskKeyboard("abc", ["A:x", "B:y"], true);
+    expect(withDetails).toHaveLength(3);
+    expect(withDetails[2]?.[0]?.callbackData).toBe("abc:DETAILS");
+  });
+
+  it("classifies the DETAILS callback payload as a recognized non-terminal verb", async () => {
+    const { classifyAnswer } = await import("./afk/telegram");
+    const result = classifyAnswer("abc123:DETAILS");
+    expect(result.recognized).toBe(true);
+    expect(result.verb).toBe("DETAILS");
+  });
+});
+
+describe("grace afk CLI — argument validation and fallbacks", () => {
+  it("journal rejects an unknown --class value with EXIT_BAD_ARGS", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+
+    const result = runCli(root, [
+      "journal",
+      "--path",
+      root,
+      "--class",
+      "not-a-real-class",
+      "--title",
+      "x",
+      "--rationale",
+      "x",
+      "--outcome",
+      "x",
+    ]);
+
+    expect(result.code).toBe(2); // EXIT_BAD_ARGS
+    expect(result.stderr).toContain("invalid --class");
+    expect(result.stderr).toContain("reversible-act"); // lists allowed values
+  });
+
+  it("journal accepts --context as the canonical arg name", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+    const result = runCli(root, [
+      "journal",
+      "--path",
+      root,
+      "--class",
+      "reversible-act",
+      "--title",
+      "t",
+      "--context",
+      "plan step-1",
+      "--rationale",
+      "r",
+      "--outcome",
+      "o",
+    ]);
+    expect(result.code).toBe(0);
+
+    const docsDir = path.join(root, "docs", "afk-sessions");
+    const sessionId = require("node:fs").readdirSync(docsDir)[0];
+    const decisions = readFileSync(path.join(docsDir, sessionId, "decisions.md"), "utf8");
+    expect(decisions).toContain("plan step-1");
+  });
+
+  it("defer requires --context (or --contextLine alias) and fails with EXIT_BAD_ARGS otherwise", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+
+    const noContext = runCli(root, ["defer", "--path", root, "--question", "q"]);
+    expect(noContext.code).toBe(2);
+    expect(noContext.stderr).toContain("context");
+
+    const withAlias = runCli(root, [
+      "defer",
+      "--path",
+      root,
+      "--question",
+      "q",
+      "--contextLine",
+      "ctx-via-alias",
+    ]);
+    expect(withAlias.code).toBe(0);
+  });
+
+  it("ask exits with EXIT_CONFIG_MISSING (46) when .grace-afk.json is absent", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+
+    const result = runCli(root, [
+      "ask",
+      "--path",
+      root,
+      "--title",
+      "merge to main",
+      "--context",
+      "plan is complete",
+      "--options",
+      "A:merge;B:wait",
+      "--mypick",
+      "A",
+      "--confidence",
+      "80",
+    ]);
+
+    expect(result.code).toBe(46); // EXIT_CONFIG_MISSING
+    expect(result.stderr).toContain("Telegram not configured");
+    expect(result.stderr).toContain("defer");
+  });
+
+  it("check returns {status:pending} when no answer is cached and Telegram is not configured", () => {
+    // Post-openAsks redesign: check reads state.answers first. Without a cached answer and
+    // without telegram config it simply reports pending (no network, exit 0) — the agent keeps
+    // calling `grace afk tick` to drain future taps whenever they arrive.
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+
+    const result = runCli(root, [
+      "check",
+      "--path",
+      root,
+      "--correlation",
+      "abc123",
+      "--messageid",
+      "42",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('"status":"pending"');
+  });
+
+  it("ask refuses after max escalations with EXIT_BAD_ARGS", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "1", "--path", root]);
+
+    // Drop a config that points at an unreachable telegram API so sendMessage will never be called
+    // once the max-escalations gate fires. We bump escalations via direct state.json edits.
+    const docsDir = path.join(root, "docs", "afk-sessions");
+    const sessionId = require("node:fs").readdirSync(docsDir)[0];
+    const statePath = path.join(docsDir, sessionId, "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    state.escalations = 3;
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+    // Minimal config so `getTelegram` returns non-null and the code proceeds to the cap check.
+    writeFileSync(
+      path.join(root, ".grace-afk.json"),
+      JSON.stringify({
+        telegram: { botToken: "x", chatId: "y" },
+        autoStop: { maxEscalationsPerSession: 3 },
+      }),
+    );
+
+    const result = runCli(root, [
+      "ask",
+      "--path",
+      root,
+      "--title",
+      "t",
+      "--context",
+      "c",
+      "--options",
+      "A:x;B:y",
+    ]);
+
+    expect(result.code).toBe(2); // EXIT_BAD_ARGS per post-review unification
+    expect(result.stderr).toContain("max 3 escalations");
+    expect(result.stderr).toContain("defer");
+  });
+
+  it("ask reads global ~/.grace/afk.json when no project-local config exists", () => {
+    const root = tmpProject();
+    const home = mkdtempSync(path.join(os.tmpdir(), "grace-afk-cli-home-"));
+    // Plant a global config in the fake home. Project root has no .grace-afk.json.
+    const globalDir = path.join(home, ".grace");
+    require("node:fs").mkdirSync(globalDir, { recursive: true });
+    writeFileSync(
+      path.join(globalDir, "afk.json"),
+      JSON.stringify({
+        telegram: { botToken: "global-bot", chatId: "global-chat" },
+        autoStop: { maxEscalationsPerSession: 3 },
+      }),
+    );
+
+    runCli(root, ["start", "1", "--path", root], { home });
+
+    // Bump escalations so we hit the max-escalations guard before touching telegram.
+    const docsDir = path.join(root, "docs", "afk-sessions");
+    const sessionId = require("node:fs").readdirSync(docsDir)[0];
+    const statePath = path.join(docsDir, sessionId, "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    state.escalations = 3;
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+    const result = runCli(
+      root,
+      ["ask", "--path", root, "--title", "t", "--context", "c", "--options", "A:x;B:y"],
+      { home },
+    );
+
+    // Hitting max-escalations (exit 2) proves the global config was loaded — otherwise we'd
+    // have gotten EXIT_CONFIG_MISSING (46) first.
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("max 3 escalations");
+  });
+
+  it("tick updates lastTickAt atomically and is safe to call repeatedly", () => {
+    const root = tmpProject();
+    runCli(root, ["start", "2", "--path", root]);
+
+    // 3 iterations is enough to verify the atomic rename path without blowing the test timeout
+    // on Windows where each `bun` spawn is ~500ms. The original 10-loop hit the 5s default.
+    for (let index = 0; index < 3; index += 1) {
+      const tick = runCli(root, ["tick", "--path", root]);
+      expect(tick.code).toBe(0);
+    }
+
+    const docsDir = path.join(root, "docs", "afk-sessions");
+    const sessionId = require("node:fs").readdirSync(docsDir)[0];
+    const statePath = path.join(docsDir, sessionId, "state.json");
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    expect(state.lastTickAt).toBeTruthy();
+    expect(state.status).toBe("active");
+  });
+});

--- a/src/afk-config.test.ts
+++ b/src/afk-config.test.ts
@@ -1,0 +1,180 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "bun:test";
+
+import {
+  getMaxEscalations,
+  getTelegram,
+  loadAfkConfig,
+  resolveAfkConfigPath,
+} from "./afk/config";
+
+function tmpProject() {
+  return mkdtempSync(path.join(os.tmpdir(), "grace-afk-config-"));
+}
+
+function tmpHome() {
+  return mkdtempSync(path.join(os.tmpdir(), "grace-afk-home-"));
+}
+
+function writeGlobalConfig(home: string, body: unknown) {
+  const dir = path.join(home, ".grace");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "afk.json"), JSON.stringify(body));
+}
+
+describe("resolveAfkConfigPath", () => {
+  it("returns null when no candidate exists", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    expect(resolveAfkConfigPath(root, { env: {}, home })).toBeNull();
+  });
+
+  it("uses $GRACE_AFK_CONFIG when it points to an existing file", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    const envPath = path.join(tmpProject(), "custom.json");
+    writeFileSync(envPath, "{}");
+
+    const resolved = resolveAfkConfigPath(root, {
+      env: { GRACE_AFK_CONFIG: envPath },
+      home,
+    });
+    expect(resolved?.source).toBe("env");
+    expect(resolved?.filePath).toBe(envPath);
+  });
+
+  it("prefers project-local over global", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    writeFileSync(path.join(root, ".grace-afk.json"), "{}");
+    writeGlobalConfig(home, { telegram: { botToken: "g", chatId: "g" } });
+
+    const resolved = resolveAfkConfigPath(root, { env: {}, home });
+    expect(resolved?.source).toBe("project");
+    expect(resolved?.filePath).toBe(path.join(root, ".grace-afk.json"));
+  });
+
+  it("falls back to global when project-local is absent", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    writeGlobalConfig(home, { telegram: { botToken: "g", chatId: "g" } });
+
+    const resolved = resolveAfkConfigPath(root, { env: {}, home });
+    expect(resolved?.source).toBe("global");
+    expect(resolved?.filePath).toBe(path.join(home, ".grace", "afk.json"));
+  });
+
+  it("ignores $GRACE_AFK_CONFIG when the referenced file is missing", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    writeGlobalConfig(home, {});
+
+    const resolved = resolveAfkConfigPath(root, {
+      env: { GRACE_AFK_CONFIG: "/path/that/does/not/exist.json" },
+      home,
+    });
+    expect(resolved?.source).toBe("global");
+  });
+});
+
+describe("loadAfkConfig", () => {
+  it("returns null + descriptive error when no config exists anywhere", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    const { config, source, error } = loadAfkConfig(root, { env: {}, home });
+
+    expect(config).toBeNull();
+    expect(source).toBeNull();
+    expect(error).toContain("grace-afk config not found");
+  });
+
+  it("parses a valid project-local config and reports source=project", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    writeFileSync(
+      path.join(root, ".grace-afk.json"),
+      JSON.stringify({
+        telegram: { botToken: "abc", chatId: "123" },
+        autoStop: { maxEscalationsPerSession: 5 },
+      }),
+    );
+
+    const { config, source, error } = loadAfkConfig(root, { env: {}, home });
+
+    expect(error).toBeNull();
+    expect(source).toBe("project");
+    expect(config?.telegram?.botToken).toBe("abc");
+    expect(config?.telegram?.chatId).toBe("123");
+    expect(config?.autoStop?.maxEscalationsPerSession).toBe(5);
+  });
+
+  it("parses a global config when no project-local override exists", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    writeGlobalConfig(home, {
+      telegram: { botToken: "global-token", chatId: "global-chat" },
+    });
+
+    const { config, source, error } = loadAfkConfig(root, { env: {}, home });
+
+    expect(error).toBeNull();
+    expect(source).toBe("global");
+    expect(config?.telegram?.botToken).toBe("global-token");
+  });
+
+  it("returns null + error on invalid JSON at the resolved path", () => {
+    const root = tmpProject();
+    const home = tmpHome();
+    writeFileSync(path.join(root, ".grace-afk.json"), "{ not valid json");
+
+    const { config, source, error } = loadAfkConfig(root, { env: {}, home });
+
+    expect(config).toBeNull();
+    expect(source).toBeNull();
+    expect(error).toContain("Failed to parse");
+  });
+});
+
+describe("getTelegram", () => {
+  it("returns null if config is null", () => {
+    expect(getTelegram(null)).toBeNull();
+  });
+
+  it("returns null if botToken is missing", () => {
+    expect(getTelegram({ telegram: { botToken: "", chatId: "1" } })).toBeNull();
+  });
+
+  it("returns null if chatId is missing", () => {
+    expect(getTelegram({ telegram: { botToken: "1", chatId: "" } })).toBeNull();
+  });
+
+  it("returns the credentials when both are present", () => {
+    const result = getTelegram({ telegram: { botToken: "token", chatId: "chat" } });
+    expect(result).toEqual({ botToken: "token", chatId: "chat" });
+  });
+});
+
+describe("getMaxEscalations", () => {
+  it("defaults to 3 when config is null", () => {
+    expect(getMaxEscalations(null)).toBe(3);
+  });
+
+  it("defaults to 3 when autoStop is not set", () => {
+    expect(getMaxEscalations({})).toBe(3);
+  });
+
+  it("honors a configured value", () => {
+    expect(getMaxEscalations({ autoStop: { maxEscalationsPerSession: 7 } })).toBe(7);
+  });
+
+  it("falls back when configured value is negative or non-finite", () => {
+    expect(getMaxEscalations({ autoStop: { maxEscalationsPerSession: -1 } })).toBe(3);
+    expect(getMaxEscalations({ autoStop: { maxEscalationsPerSession: Number.NaN } })).toBe(3);
+  });
+
+  it("accepts a custom fallback", () => {
+    expect(getMaxEscalations(null, 10)).toBe(10);
+  });
+});

--- a/src/afk-session.test.ts
+++ b/src/afk-session.test.ts
@@ -1,0 +1,179 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "bun:test";
+
+import {
+  checkActive,
+  createSession,
+  findActiveSession,
+  incrementCounter,
+  listSessions,
+  markCompleted,
+  markStopped,
+  readSession,
+  resolveSessionPaths,
+} from "./afk/session";
+import { appendDecision, appendDeferred, readJournal } from "./afk/journal";
+
+function tmpProject() {
+  return mkdtempSync(path.join(os.tmpdir(), "grace-afk-"));
+}
+
+describe("afk session create + read", () => {
+  it("creates session directory and state.json under docs/afk-sessions/<id>/", () => {
+    const root = tmpProject();
+    const now = new Date("2026-04-18T10:00:00Z");
+    const state = createSession(root, { hours: 2 }, now);
+
+    expect(state.status).toBe("active");
+    expect(state.hours).toBe(2);
+    expect(new Date(state.expiresAt).getTime() - now.getTime()).toBe(2 * 3600 * 1000);
+
+    const paths = resolveSessionPaths(root, state.id);
+    expect(existsSync(paths.statePath)).toBe(true);
+    expect(existsSync(paths.dir)).toBe(true);
+
+    const fromDisk = readSession(root, state.id);
+    expect(fromDisk?.id).toBe(state.id);
+    expect(listSessions(root)).toEqual([state.id]);
+  });
+
+  it("validates hours range (0 < h <= 24)", () => {
+    const root = tmpProject();
+    expect(() => createSession(root, { hours: 0 })).toThrow();
+    expect(() => createSession(root, { hours: 25 })).toThrow();
+    expect(() => createSession(root, { hours: -1 })).toThrow();
+  });
+
+  it("validates checkpoint range", () => {
+    const root = tmpProject();
+    expect(() => createSession(root, { hours: 1, checkpointMinutes: 2 })).toThrow();
+    expect(() => createSession(root, { hours: 1, checkpointMinutes: 500 })).toThrow();
+  });
+});
+
+describe("afk session active check", () => {
+  it("returns ok for a fresh session", () => {
+    const root = tmpProject();
+    const start = new Date("2026-04-18T10:00:00Z");
+    createSession(root, { hours: 2 }, start);
+
+    const check = checkActive(root, new Date("2026-04-18T10:30:00Z"));
+    expect(check.ok).toBe(true);
+    if (check.ok) {
+      expect(check.remainingMs).toBe(90 * 60 * 1000);
+    }
+  });
+
+  it("returns expired once past expiresAt", () => {
+    const root = tmpProject();
+    const start = new Date("2026-04-18T10:00:00Z");
+    createSession(root, { hours: 1 }, start);
+
+    const check = checkActive(root, new Date("2026-04-18T11:30:00Z"));
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.reason).toBe("expired");
+    }
+  });
+
+  it("returns stopped after markStopped", () => {
+    const root = tmpProject();
+    const state = createSession(root, { hours: 2 });
+    markStopped(root, state.id, "user-requested");
+
+    const check = checkActive(root);
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.reason).toBe("stopped");
+    }
+  });
+
+  it("returns no-active-session for empty project", () => {
+    const root = tmpProject();
+    const check = checkActive(root);
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.reason).toBe("no-active-session");
+    }
+  });
+});
+
+describe("afk counters", () => {
+  it("increments commits / escalations / deferred independently", () => {
+    const root = tmpProject();
+    const state = createSession(root, { hours: 2 });
+
+    incrementCounter(root, state.id, "commits");
+    incrementCounter(root, state.id, "commits");
+    incrementCounter(root, state.id, "escalations");
+    incrementCounter(root, state.id, "deferred");
+    incrementCounter(root, state.id, "deferred");
+    incrementCounter(root, state.id, "deferred");
+
+    const fromDisk = readSession(root, state.id)!;
+    expect(fromDisk.commits).toBe(2);
+    expect(fromDisk.escalations).toBe(1);
+    expect(fromDisk.deferred).toBe(3);
+  });
+});
+
+describe("afk completed state", () => {
+  it("markCompleted makes the session not-active", () => {
+    const root = tmpProject();
+    const state = createSession(root, { hours: 2 });
+    markCompleted(root, state.id);
+
+    expect(findActiveSession(root)).toBeNull();
+    const fromDisk = readSession(root, state.id)!;
+    expect(fromDisk.status).toBe("completed");
+  });
+});
+
+describe("afk journal", () => {
+  it("appends decisions with a header and an entry", () => {
+    const root = tmpProject();
+    const state = createSession(root, { hours: 2 });
+    const paths = resolveSessionPaths(root, state.id);
+
+    appendDecision(paths.decisionsPath, {
+      timestamp: "2026-04-18T11:00:00Z",
+      klass: "reversible-act",
+      title: "Refactor helper",
+      context: "Phase-4 step-3",
+      rationale: "Test coverage was 60%, needed factoring out.",
+      outcome: "commit abc1234",
+    });
+
+    const text = readFileSync(paths.decisionsPath, "utf8");
+    expect(text).toContain("# /afk decisions journal");
+    expect(text).toContain("Refactor helper");
+    expect(text).toContain("reversible-act");
+    expect(text).toContain("commit abc1234");
+  });
+
+  it("appends deferred questions as single lines", () => {
+    const root = tmpProject();
+    const state = createSession(root, { hours: 2 });
+    const paths = resolveSessionPaths(root, state.id);
+
+    appendDeferred(paths.deferredPath, {
+      timestamp: "2026-04-18T11:05:00Z",
+      question: "Merge strategy for M-FOO?",
+      context: "Phase-5 gate",
+      suggestion: "squash",
+    });
+    appendDeferred(paths.deferredPath, {
+      timestamp: "2026-04-18T11:15:00Z",
+      question: "Release version?",
+      context: "main branch",
+    });
+
+    const text = readJournal(paths.deferredPath);
+    const dataLines = text.split("\n").filter((line) => line.startsWith("- ["));
+    expect(dataLines).toHaveLength(2);
+    expect(dataLines[0]).toContain("Merge strategy");
+    expect(dataLines[0]).toContain("squash");
+  });
+});

--- a/src/afk-telegram.test.ts
+++ b/src/afk-telegram.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  answerCallbackQuery,
+  classifyAnswer,
+  editMessageRemoveKeyboard,
+  fetchUpdates,
+  matchReply,
+  sendMessage,
+  type TelegramTransport,
+} from "./afk/telegram";
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function mockTransport(entries: Array<{ test: (url: string) => boolean; body: unknown }>): {
+  transport: TelegramTransport;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const transport: TelegramTransport = async (url) => {
+    calls.push(url);
+    for (const entry of entries) {
+      if (entry.test(url)) {
+        return okResponse(entry.body);
+      }
+    }
+    return okResponse({ ok: false, description: "no mock for " + url });
+  };
+  return { transport, calls };
+}
+
+describe("telegram sendMessage", () => {
+  it("posts to sendMessage and returns messageId on success", async () => {
+    const { transport, calls } = mockTransport([
+      { test: (url) => url.endsWith("/sendMessage"), body: { ok: true, result: { message_id: 42 } } },
+    ]);
+
+    const result = await sendMessage({ botToken: "t", chatId: "123" }, "hello", null, transport);
+
+    expect(result.ok).toBe(true);
+    expect(result.messageId).toBe(42);
+    expect(calls[0]).toContain("/bott/sendMessage");
+  });
+
+  it("returns ok=false with error description on failure", async () => {
+    const { transport } = mockTransport([
+      { test: (url) => url.endsWith("/sendMessage"), body: { ok: false, description: "chat not found" } },
+    ]);
+
+    const result = await sendMessage({ botToken: "t", chatId: "123" }, "hello", null, transport);
+
+    expect(result.ok).toBe(false);
+    expect(result.errorDescription).toBe("chat not found");
+  });
+
+  it("includes inline_keyboard payload when a keyboard is provided", async () => {
+    let capturedBody: any = null;
+    const transport: TelegramTransport = async (_url, init) => {
+      capturedBody = JSON.parse(String(init?.body ?? "{}"));
+      return okResponse({ ok: true, result: { message_id: 99 } });
+    };
+
+    const keyboard = [
+      [{ text: "A", callbackData: "abc:A" }, { text: "B", callbackData: "abc:B" }],
+      [{ text: "STOP", callbackData: "abc:STOP" }],
+    ];
+    const result = await sendMessage({ botToken: "t", chatId: "1" }, "hi", keyboard, transport);
+
+    expect(result.ok).toBe(true);
+    expect(capturedBody.reply_markup.inline_keyboard[0]).toHaveLength(2);
+    expect(capturedBody.reply_markup.inline_keyboard[0][0]).toEqual({ text: "A", callback_data: "abc:A" });
+    expect(capturedBody.reply_markup.inline_keyboard[1][0]).toEqual({ text: "STOP", callback_data: "abc:STOP" });
+  });
+
+  it("omits reply_markup when keyboard is null or empty", async () => {
+    let capturedBody: any = null;
+    const transport: TelegramTransport = async (_url, init) => {
+      capturedBody = JSON.parse(String(init?.body ?? "{}"));
+      return okResponse({ ok: true, result: { message_id: 1 } });
+    };
+
+    await sendMessage({ botToken: "t", chatId: "1" }, "hi", null, transport);
+    expect(capturedBody.reply_markup).toBeUndefined();
+
+    await sendMessage({ botToken: "t", chatId: "1" }, "hi", [], transport);
+    expect(capturedBody.reply_markup).toBeUndefined();
+  });
+});
+
+describe("answerCallbackQuery", () => {
+  it("posts to /answerCallbackQuery with the callback id", async () => {
+    let capturedBody: any = null;
+    const transport: TelegramTransport = async (url, init) => {
+      expect(url).toContain("/answerCallbackQuery");
+      capturedBody = JSON.parse(String(init?.body ?? "{}"));
+      return okResponse({ ok: true });
+    };
+    const result = await answerCallbackQuery({ botToken: "t", chatId: "1" }, "cb-1", "Received: A", transport);
+    expect(result.ok).toBe(true);
+    expect(capturedBody.callback_query_id).toBe("cb-1");
+    expect(capturedBody.text).toBe("Received: A");
+  });
+});
+
+describe("editMessageRemoveKeyboard", () => {
+  it("posts an empty inline_keyboard to /editMessageReplyMarkup", async () => {
+    let capturedBody: any = null;
+    const transport: TelegramTransport = async (url, init) => {
+      expect(url).toContain("/editMessageReplyMarkup");
+      capturedBody = JSON.parse(String(init?.body ?? "{}"));
+      return okResponse({ ok: true });
+    };
+    const result = await editMessageRemoveKeyboard({ botToken: "t", chatId: "1" }, 42, transport);
+    expect(result.ok).toBe(true);
+    expect(capturedBody.message_id).toBe(42);
+    expect(capturedBody.reply_markup).toEqual({ inline_keyboard: [] });
+  });
+});
+
+describe("telegram fetchUpdates", () => {
+  it("returns replies only from matching chat id", async () => {
+    const { transport } = mockTransport([
+      {
+        test: (url) => url.includes("/getUpdates"),
+        body: {
+          ok: true,
+          result: [
+            { update_id: 1, message: { text: "A", chat: { id: 123 } } },
+            { update_id: 2, message: { text: "ignore", chat: { id: 999 } } },
+            { update_id: 3, message: { text: "B", chat: { id: 123 }, reply_to_message: { message_id: 42 } } },
+          ],
+        },
+      },
+    ]);
+
+    const replies = await fetchUpdates({ botToken: "t", chatId: "123" }, null, transport);
+
+    expect(replies).toHaveLength(2);
+    expect(replies[0]?.text).toBe("A");
+    expect(replies[1]?.fromMessageId).toBe(42);
+  });
+
+  it("passes offset when provided and now asks for message+callback_query", async () => {
+    const { transport, calls } = mockTransport([
+      { test: (url) => url.includes("/getUpdates"), body: { ok: true, result: [] } },
+    ]);
+
+    await fetchUpdates({ botToken: "t", chatId: "1" }, 500, transport);
+
+    expect(calls[0]).toContain("offset=500");
+    expect(calls[0]).toContain("callback_query");
+  });
+
+  it("parses callback_query updates with callbackQueryId + fromMessageId", async () => {
+    const { transport } = mockTransport([
+      {
+        test: (url) => url.includes("/getUpdates"),
+        body: {
+          ok: true,
+          result: [
+            {
+              update_id: 7,
+              callback_query: {
+                id: "cb-abc",
+                data: "abc123:A",
+                message: { message_id: 88, chat: { id: 123 } },
+                from: { id: 42 },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const replies = await fetchUpdates({ botToken: "t", chatId: "123" }, null, transport);
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]?.text).toBe("abc123:A");
+    expect(replies[0]?.callbackQueryId).toBe("cb-abc");
+    expect(replies[0]?.fromMessageId).toBe(88);
+  });
+
+  it("ignores callback_query from other chats", async () => {
+    const { transport } = mockTransport([
+      {
+        test: (url) => url.includes("/getUpdates"),
+        body: {
+          ok: true,
+          result: [
+            {
+              update_id: 9,
+              callback_query: {
+                id: "cb-wrong",
+                data: "abc:A",
+                message: { message_id: 1, chat: { id: 999 } },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    const replies = await fetchUpdates({ botToken: "t", chatId: "123" }, null, transport);
+    expect(replies).toHaveLength(0);
+  });
+});
+
+describe("matchReply", () => {
+  it("matches by reply_to_message_id", () => {
+    const reply = { updateId: 1, text: "B", chatId: "1", fromMessageId: 42 };
+    expect(matchReply(reply, 42, "xyz")).toBe(true);
+    expect(matchReply(reply, 99, "xyz")).toBe(false);
+  });
+
+  it("matches by first token equal to correlation id", () => {
+    const reply = { updateId: 1, text: "abc123 B", chatId: "1" };
+    expect(matchReply(reply, 0, "abc123")).toBe(true);
+    expect(matchReply(reply, 0, "nomatch")).toBe(false);
+  });
+
+  it("matches a callback-query payload whose text starts with `<corrId>:`", () => {
+    const reply = { updateId: 1, text: "abc123:PROCEED", chatId: "1", callbackQueryId: "cb-1" };
+    expect(matchReply(reply, 0, "abc123")).toBe(true);
+    expect(matchReply(reply, 0, "nomatch")).toBe(false);
+  });
+});
+
+describe("classifyAnswer", () => {
+  it("recognizes single letter options A-E when the letter stands alone", () => {
+    expect(classifyAnswer("A").verb).toBe("A");
+    expect(classifyAnswer("b").verb).toBe("B");
+    expect(classifyAnswer(" c ").verb).toBe("C");
+    expect(classifyAnswer("A").recognized).toBe(true);
+  });
+
+  it("recognizes verbs proceed / stop / evolve / defer", () => {
+    expect(classifyAnswer("proceed").verb).toBe("PROCEED");
+    expect(classifyAnswer("STOP").verb).toBe("STOP");
+    expect(classifyAnswer("defer now").verb).toBe("DEFER");
+    expect(classifyAnswer("yes proceed").verb).toBe("PROCEED");
+  });
+
+  it("recognizes an answer prefixed by a correlation id", () => {
+    expect(classifyAnswer("abc123 PROCEED").verb).toBe("PROCEED");
+    expect(classifyAnswer("abc123 STOP").verb).toBe("STOP");
+  });
+
+  it("returns UNKNOWN with recognized=false for free-form text", () => {
+    const result = classifyAnswer("let me think about it");
+    expect(result.verb).toBe("UNKNOWN");
+    expect(result.recognized).toBe(false);
+    expect(result.raw).toBe("let me think about it");
+  });
+
+  it("rejects replies containing a negation alongside a verb", () => {
+    expect(classifyAnswer("do not STOP").recognized).toBe(false);
+    expect(classifyAnswer("dont proceed").recognized).toBe(false);
+    expect(classifyAnswer("never defer").recognized).toBe(false);
+    expect(classifyAnswer("cancel PROCEED").recognized).toBe(false);
+  });
+
+  it("rejects free-form replies longer than 3 tokens even if a verb appears", () => {
+    expect(classifyAnswer("I think we should PROCEED").recognized).toBe(false);
+    expect(classifyAnswer("do not STOP do not PROCEED").recognized).toBe(false);
+  });
+
+  it("rejects single letters embedded in free-form text (regression: 'a cat' -> A)", () => {
+    expect(classifyAnswer("a cat").recognized).toBe(false);
+    expect(classifyAnswer("B please").recognized).toBe(false);
+    expect(classifyAnswer("option C maybe").recognized).toBe(false);
+  });
+
+  it("rejects empty / whitespace-only replies", () => {
+    expect(classifyAnswer("").recognized).toBe(false);
+    expect(classifyAnswer("   ").recognized).toBe(false);
+  });
+
+  it("classifies inline-button callback payloads `<corrId>:<verb>` exactly", () => {
+    expect(classifyAnswer("abc123:A").verb).toBe("A");
+    expect(classifyAnswer("deadbe:PROCEED").verb).toBe("PROCEED");
+    expect(classifyAnswer("d99d:STOP").verb).toBe("STOP");
+    expect(classifyAnswer("abc123:XYZ").recognized).toBe(false);
+  });
+});

--- a/src/afk-usage.test.ts
+++ b/src/afk-usage.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "bun:test";
+
+import { readUsage, renderUsageLine } from "./afk/usage";
+
+function tmpFile(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grace-usage-"));
+  return path.join(dir, "statusline-usage-cache.json");
+}
+
+describe("readUsage", () => {
+  it("returns null when the cache file is missing", () => {
+    expect(readUsage("/does/not/exist")).toBeNull();
+  });
+
+  it("returns null when the JSON is malformed", () => {
+    const file = tmpFile();
+    writeFileSync(file, "{ not json");
+    expect(readUsage(file)).toBeNull();
+  });
+
+  it("parses five_hour / seven_day / extra_usage fields", () => {
+    const file = tmpFile();
+    writeFileSync(
+      file,
+      JSON.stringify({
+        five_hour: { utilization: 7, resets_at: "2026-04-19T07:00:00+00:00" },
+        seven_day: { utilization: 21.4, resets_at: "2026-04-23T18:00:00+00:00" },
+        extra_usage: {
+          is_enabled: true,
+          monthly_limit: 6000,
+          used_credits: 1468,
+          utilization: 24.47,
+          currency: "USD",
+        },
+      }),
+    );
+
+    const snap = readUsage(file)!;
+    expect(snap.fiveHourPct).toBe(7);
+    expect(snap.sevenDayPct).toBe(21);
+    expect(snap.fiveHourResetsAt).toContain("2026-04-19T07");
+    expect(snap.extra?.usedCredits).toBeCloseTo(14.68, 2);
+    expect(snap.extra?.monthlyLimit).toBeCloseTo(60, 2);
+    expect(snap.extra?.currency).toBe("USD");
+  });
+
+  it("returns extra=null when extra_usage.is_enabled is false", () => {
+    const file = tmpFile();
+    writeFileSync(
+      file,
+      JSON.stringify({
+        five_hour: { utilization: 10 },
+        seven_day: { utilization: 5 },
+        extra_usage: { is_enabled: false },
+      }),
+    );
+    const snap = readUsage(file)!;
+    expect(snap.extra).toBeNull();
+  });
+
+  it("returns null when neither five_hour nor seven_day utilization is present", () => {
+    const file = tmpFile();
+    writeFileSync(file, JSON.stringify({ unrelated: 1 }));
+    expect(readUsage(file)).toBeNull();
+  });
+});
+
+describe("renderUsageLine", () => {
+  it("emits the fallback when snapshot is null", () => {
+    expect(renderUsageLine(null)).toContain("unavailable");
+  });
+
+  it("formats 5h/7d and $ line in one line separated by middle dots", () => {
+    const line = renderUsageLine({
+      fiveHourPct: 7,
+      sevenDayPct: 21,
+      fiveHourResetsAt: null,
+      sevenDayResetsAt: null,
+      extra: { usedCredits: 14.68, monthlyLimit: 60, currency: "USD", pct: 24.47 },
+      ageSeconds: 5,
+      source: "mock",
+    });
+    expect(line).toContain("5h 7%");
+    expect(line).toContain("7d 21%");
+    expect(line).toContain("$14.68/60.00");
+    expect(line).toContain("cache age 5s");
+  });
+});

--- a/src/afk/config.ts
+++ b/src/afk/config.ts
@@ -1,0 +1,133 @@
+// FILE: src/afk/config.ts
+// VERSION: 1.1.0
+// START_MODULE_CONTRACT
+//   PURPOSE: Parse grace-afk.json holding Telegram credentials and autoStop caps for /afk sessions, with a lookup priority that lets one global config serve all projects on the machine.
+//   SCOPE: Read-only config loading + accessor helpers. Resolves config path via env override, project-local, then global user-home location. No I/O beyond fs.readFileSync.
+//   DEPENDS: node:fs, node:os, node:path
+//   LINKS: M-AFK-CONFIG
+//   ROLE: RUNTIME
+//   MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   AfkConfig              - Shape of grace-afk.json: telegram credentials + autoStop caps
+//   ConfigSource           - Which location on disk the loaded config came from
+//   resolveAfkConfigPath   - Apply env/project/global lookup order; returns path + source or null
+//   loadAfkConfig          - Read and parse grace-afk.json from the resolved location
+//   getTelegram            - Extract botToken/chatId; returns null if either missing
+//   getMaxEscalations      - Resolve per-session escalation cap; default 3
+// END_MODULE_MAP
+
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type AfkConfig = {
+  telegram?: {
+    botToken: string;
+    chatId: string;
+  };
+  autoStop?: {
+    maxEscalationsPerSession?: number;
+  };
+};
+
+export type ConfigSource = "env" | "project" | "global";
+
+const PROJECT_CONFIG_FILE = ".grace-afk.json";
+const GLOBAL_CONFIG_SUBDIR = ".grace";
+const GLOBAL_CONFIG_FILE = "afk.json";
+const ENV_OVERRIDE = "GRACE_AFK_CONFIG";
+
+// START_CONTRACT: resolveAfkConfigPath
+//   PURPOSE: Resolve which grace-afk config path to use for a given project root, by priority: $GRACE_AFK_CONFIG env override, then <projectRoot>/.grace-afk.json, then <home>/.grace/afk.json.
+//   INPUTS: { projectRoot: string - absolute path to the project root, env?: NodeJS.ProcessEnv - environment to read (defaults to process.env), home?: string - home directory override for tests }
+//   OUTPUTS: { filePath: string, source: ConfigSource } | null - null when no candidate exists
+//   SIDE_EFFECTS: reads environment + filesystem existsSync checks only
+// END_CONTRACT: resolveAfkConfigPath
+export function resolveAfkConfigPath(
+  projectRoot: string,
+  options: { env?: NodeJS.ProcessEnv; home?: string } = {},
+): { filePath: string; source: ConfigSource } | null {
+  const env = options.env ?? process.env;
+  const home = options.home ?? os.homedir();
+
+  const envOverride = env[ENV_OVERRIDE];
+  if (envOverride && existsSync(envOverride)) {
+    return { filePath: envOverride, source: "env" };
+  }
+
+  const projectPath = path.join(projectRoot, PROJECT_CONFIG_FILE);
+  if (existsSync(projectPath)) {
+    return { filePath: projectPath, source: "project" };
+  }
+
+  const globalPath = path.join(home, GLOBAL_CONFIG_SUBDIR, GLOBAL_CONFIG_FILE);
+  if (existsSync(globalPath)) {
+    return { filePath: globalPath, source: "global" };
+  }
+
+  return null;
+}
+
+// START_CONTRACT: loadAfkConfig
+//   PURPOSE: Resolve the grace-afk config path and parse it. Accepts any of: env override, project-local .grace-afk.json, or global ~/.grace/afk.json.
+//   INPUTS: { projectRoot: string - absolute path to the project root, options?: { env?: NodeJS.ProcessEnv, home?: string } - test hooks }
+//   OUTPUTS: { config: AfkConfig | null, source: ConfigSource | null, error: string | null } - exactly one of (config,source) or error is populated
+//   SIDE_EFFECTS: Reads the file system. Never throws; all failures surface in `error`.
+// END_CONTRACT: loadAfkConfig
+export function loadAfkConfig(
+  projectRoot: string,
+  options: { env?: NodeJS.ProcessEnv; home?: string } = {},
+): { config: AfkConfig | null; source: ConfigSource | null; error: string | null } {
+  const resolved = resolveAfkConfigPath(projectRoot, options);
+  if (!resolved) {
+    return {
+      config: null,
+      source: null,
+      error: `grace-afk config not found. Looked at $${ENV_OVERRIDE}, ${path.join(projectRoot, PROJECT_CONFIG_FILE)}, and ~/${GLOBAL_CONFIG_SUBDIR}/${GLOBAL_CONFIG_FILE}`,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(resolved.filePath, "utf8")) as AfkConfig;
+    return { config: parsed, source: resolved.source, error: null };
+  } catch (error) {
+    return {
+      config: null,
+      source: null,
+      error: `Failed to parse grace-afk config at ${resolved.filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+// START_CONTRACT: getTelegram
+//   PURPOSE: Return Telegram credentials only when both botToken and chatId are present.
+//   INPUTS: { config: AfkConfig | null }
+//   OUTPUTS: { botToken: string, chatId: string } | null
+//   SIDE_EFFECTS: none
+// END_CONTRACT: getTelegram
+export function getTelegram(config: AfkConfig | null) {
+  if (!config?.telegram?.botToken || !config.telegram.chatId) {
+    return null;
+  }
+  return { botToken: config.telegram.botToken, chatId: config.telegram.chatId };
+}
+
+// START_CONTRACT: getMaxEscalations
+//   PURPOSE: Resolve the per-session Telegram-escalation cap with a safe default.
+//   INPUTS: { config: AfkConfig | null, fallback?: number - default 3 }
+//   OUTPUTS: number - finite, non-negative
+//   SIDE_EFFECTS: none
+// END_CONTRACT: getMaxEscalations
+export function getMaxEscalations(config: AfkConfig | null, fallback = 3) {
+  const value = config?.autoStop?.maxEscalationsPerSession;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return fallback;
+}
+
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [4.0.0-beta.2] Add config lookup priority: $GRACE_AFK_CONFIG env > <project>/.grace-afk.json > ~/.grace/afk.json. Any Claude Code session on the machine can now share one Telegram config without per-project setup. loadAfkConfig now also returns `source` (env/project/global).
+// END_CHANGE_SUMMARY

--- a/src/afk/journal.ts
+++ b/src/afk/journal.ts
@@ -1,0 +1,131 @@
+// FILE: src/afk/journal.ts
+// VERSION: 1.0.0
+// START_MODULE_CONTRACT
+//   PURPOSE: Append-only writers for /afk session journals (decisions.md + deferred.md).
+//   SCOPE: Ensure header on first write, append structured entries, read raw text. No deletion.
+//   DEPENDS: node:fs
+//   LINKS: M-AFK-JOURNAL
+//   ROLE: RUNTIME
+//   MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   DecisionClass     - Closed set of decision-class labels used by grace-afk autonomy matrix
+//   DECISION_CLASSES  - Readonly array of all decision classes (for CLI validation)
+//   isDecisionClass   - Type guard narrowing string to DecisionClass
+//   DecisionEntry     - Shape of a single line in decisions.md
+//   DeferredEntry     - Shape of a single line in deferred.md
+//   appendDecision    - Append a decision entry (writes header if file is new)
+//   appendDeferred    - Append a deferred question (writes header if file is new)
+//   readJournal       - Return journal file contents or empty string if missing
+// END_MODULE_MAP
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+
+export type DecisionClass =
+  | "reversible-act"
+  | "uncertain-deferred"
+  | "one-way-door-escalated"
+  | "one-way-door-deferred"
+  | "scope-creep-deferred"
+  | "threshold-yellow-rollback"
+  | "threshold-red-escalated"
+  | "checkpoint";
+
+export const DECISION_CLASSES: readonly DecisionClass[] = [
+  "reversible-act",
+  "uncertain-deferred",
+  "one-way-door-escalated",
+  "one-way-door-deferred",
+  "scope-creep-deferred",
+  "threshold-yellow-rollback",
+  "threshold-red-escalated",
+  "checkpoint",
+];
+
+export function isDecisionClass(value: string): value is DecisionClass {
+  return (DECISION_CLASSES as readonly string[]).includes(value);
+}
+
+export type DecisionEntry = {
+  timestamp: string;
+  klass: DecisionClass;
+  title: string;
+  context: string;
+  optionsConsidered?: string[];
+  chosen?: string;
+  rationale: string;
+  outcome: string;
+};
+
+// START_BLOCK_HEADER_ENSURE
+function ensureHeader(filePath: string, header: string) {
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, header);
+  }
+}
+// END_BLOCK_HEADER_ENSURE
+
+// START_CONTRACT: appendDecision
+//   PURPOSE: Append one structured decision entry to `decisions.md`.
+//   INPUTS: { filePath: string, entry: DecisionEntry }
+//   OUTPUTS: void
+//   SIDE_EFFECTS: Writes header if file is new; appends a multi-line markdown block otherwise.
+// END_CONTRACT: appendDecision
+export function appendDecision(filePath: string, entry: DecisionEntry) {
+  ensureHeader(filePath, "# /afk decisions journal\n\n");
+  // START_BLOCK_FORMAT_DECISION
+  const lines: string[] = [];
+  lines.push(`## ${entry.timestamp} — ${entry.title}`);
+  lines.push(`- class: \`${entry.klass}\``);
+  lines.push(`- context: ${entry.context}`);
+  if (entry.optionsConsidered && entry.optionsConsidered.length > 0) {
+    lines.push(`- options: ${entry.optionsConsidered.map((option) => `\`${option}\``).join(" | ")}`);
+  }
+  if (entry.chosen) {
+    lines.push(`- chosen: \`${entry.chosen}\``);
+  }
+  lines.push(`- rationale: ${entry.rationale}`);
+  lines.push(`- outcome: ${entry.outcome}`);
+  lines.push("");
+  appendFileSync(filePath, lines.join("\n") + "\n");
+  // END_BLOCK_FORMAT_DECISION
+}
+
+export type DeferredEntry = {
+  timestamp: string;
+  question: string;
+  context: string;
+  suggestion?: string;
+};
+
+// START_CONTRACT: appendDeferred
+//   PURPOSE: Append one deferred-question line to `deferred.md`.
+//   INPUTS: { filePath: string, entry: DeferredEntry }
+//   OUTPUTS: void
+//   SIDE_EFFECTS: Writes header if file is new; appends a single line otherwise.
+// END_CONTRACT: appendDeferred
+export function appendDeferred(filePath: string, entry: DeferredEntry) {
+  ensureHeader(filePath, "# /afk deferred for human review\n\nOne line per question. Review on return.\n\n");
+  const suggestion = entry.suggestion ? ` (suggestion: ${entry.suggestion})` : "";
+  const line = `- [${entry.timestamp}] ${entry.question} — context: ${entry.context}${suggestion}\n`;
+  appendFileSync(filePath, line);
+}
+
+// START_CONTRACT: readJournal
+//   PURPOSE: Return the current contents of a journal file, or empty string if it does not exist.
+//   INPUTS: { filePath: string }
+//   OUTPUTS: string
+//   SIDE_EFFECTS: none
+// END_CONTRACT: readJournal
+export function readJournal(filePath: string): string {
+  if (!existsSync(filePath)) {
+    return "";
+  }
+  return readFileSync(filePath, "utf8");
+}
+
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [3.7.0-grace-afk] Initial module for decisions.md + deferred.md append writers.
+//                Added DECISION_CLASSES and isDecisionClass for CLI-side validation of --class arg.
+// END_CHANGE_SUMMARY

--- a/src/afk/session.ts
+++ b/src/afk/session.ts
@@ -1,0 +1,382 @@
+// FILE: src/afk/session.ts
+// VERSION: 1.0.0
+// START_MODULE_CONTRACT
+//   PURPOSE: Session state store + budget enforcement for /afk. CLI, not the LLM, decides when the session is over.
+//   SCOPE: Create / read / write state.json atomically; expire check; counters; exit-code constants.
+//   DEPENDS: node:fs, node:crypto, node:path
+//   LINKS: M-AFK-SESSION
+//   ROLE: RUNTIME
+//   MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   SessionStatus         - "active" | "expired" | "stopped" | "completed"
+//   SessionState          - Shape of state.json
+//   ActiveSessionCheck    - Discriminated result of checkActive (ok | expired | stopped | no-session)
+//   newSessionId          - Compact ISO-ish id + 4-hex suffix (collision-safe within ms)
+//   createSession         - Validate args, create docs/afk-sessions/<id>/, write state.json
+//   listSessions          - List session ids in docs/afk-sessions
+//   findActiveSession     - Return the most recent still-active session
+//   readSession           - Read a session's state.json or null if missing
+//   writeSession          - Atomic write of state.json via .tmp + renameSync
+//   checkActive           - Discriminated check used by CLI to enforce budget
+//   markStopped           - Transition session to stopped status
+//   markCompleted         - Transition session to completed status
+//   incrementCounter      - Atomic increment of commits / escalations / deferred
+//   updateLastTick        - Stamp the last tick time
+//   formatRemaining       - Human-readable "Xh Ym" for reports
+//   resolveSessionPaths   - Resolve decisions.md / deferred.md / dashboard.md paths
+//   EXIT_BUDGET_EXHAUSTED - Numeric exit code 42
+//   EXIT_NO_SESSION       - Numeric exit code 43
+//   EXIT_SESSION_STOPPED  - Numeric exit code 44
+//   OpenAsk               - Shape: { correlationId, messageId, sentAt, title? }
+//   AnswerRecord          - Shape: { verb, raw, source, recognized, receivedAt }
+//   addOpenAsk            - Register an outstanding ask and clear any stale answer for it
+//   recordAnswer          - Persist an answer and remove its ask from openAsks
+//   getAnswer             - Look up a recorded answer without a network call
+//   listOpenAsks          - Return currently outstanding asks
+// END_MODULE_MAP
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+export type SessionStatus = "active" | "expired" | "stopped" | "completed";
+
+export type OpenAsk = {
+  correlationId: string;
+  messageId: number | null;
+  sentAt: string;
+  title?: string;
+};
+
+export type AnswerRecord = {
+  verb: string;
+  raw: string;
+  source: "button" | "text";
+  recognized: boolean;
+  receivedAt: string;
+};
+
+export type SessionState = {
+  version: 1;
+  id: string;
+  createdAt: string;
+  expiresAt: string;
+  hours: number;
+  budgetPercent: number | null;
+  checkpointMinutes: number;
+  status: SessionStatus;
+  commits: number;
+  escalations: number;
+  deferred: number;
+  lastTickAt: string | null;
+  stopReason: string | null;
+  openAsks?: OpenAsk[];
+  answers?: Record<string, AnswerRecord>;
+};
+
+const STATE_FILENAME = "state.json";
+
+function toIso(date: Date) {
+  return date.toISOString();
+}
+
+function sessionsRoot(projectRoot: string) {
+  return path.join(projectRoot, "docs", "afk-sessions");
+}
+
+function sessionDir(projectRoot: string, sessionId: string) {
+  return path.join(sessionsRoot(projectRoot), sessionId);
+}
+
+function statePath(projectRoot: string, sessionId: string) {
+  return path.join(sessionDir(projectRoot, sessionId), STATE_FILENAME);
+}
+
+export function newSessionId(now = new Date()) {
+  // Compact ISO-ish id, safe for paths across Windows/Linux, with a 4-hex-char suffix to
+  // prevent collision when two sessions happen to be created in the same millisecond (or
+  // when a test fakes `now` to a constant value, which is common).
+  const stamp = now
+    .toISOString()
+    .replace(/[:.]/g, "")
+    .replace(/Z$/, "Z")
+    .slice(0, 17);
+  return `${stamp}-${randomBytes(2).toString("hex")}`;
+}
+
+export function createSession(
+  projectRoot: string,
+  args: { hours: number; budgetPercent?: number | null; checkpointMinutes?: number },
+  now: Date = new Date(),
+): SessionState {
+  const hours = Number(args.hours);
+  if (!Number.isFinite(hours) || hours <= 0 || hours > 24) {
+    throw new Error(`hours must be in (0, 24], got ${args.hours}`);
+  }
+
+  const checkpointMinutes = args.checkpointMinutes ?? 30;
+  if (!Number.isFinite(checkpointMinutes) || checkpointMinutes < 5 || checkpointMinutes > 180) {
+    throw new Error(`--checkpoint must be in [5, 180] minutes, got ${checkpointMinutes}`);
+  }
+
+  const expiresAt = new Date(now.getTime() + hours * 3600 * 1000);
+  const id = newSessionId(now);
+  const state: SessionState = {
+    version: 1,
+    id,
+    createdAt: toIso(now),
+    expiresAt: toIso(expiresAt),
+    hours,
+    budgetPercent: args.budgetPercent ?? null,
+    checkpointMinutes,
+    status: "active",
+    commits: 0,
+    escalations: 0,
+    deferred: 0,
+    lastTickAt: null,
+    stopReason: null,
+    openAsks: [],
+    answers: {},
+  };
+
+  const dir = sessionDir(projectRoot, id);
+  mkdirSync(dir, { recursive: true });
+  writeSession(projectRoot, state);
+  return state;
+}
+
+export function listSessions(projectRoot: string): string[] {
+  const root = sessionsRoot(projectRoot);
+  if (!existsSync(root)) {
+    return [];
+  }
+  return readdirSync(root)
+    .filter((name) => statSync(path.join(root, name)).isDirectory())
+    .sort();
+}
+
+export function findActiveSession(projectRoot: string, now: Date = new Date()): SessionState | null {
+  const ids = listSessions(projectRoot);
+  for (let index = ids.length - 1; index >= 0; index -= 1) {
+    const id = ids[index]!;
+    const state = readSession(projectRoot, id);
+    if (!state) {
+      continue;
+    }
+    if (state.status === "active" && new Date(state.expiresAt).getTime() > now.getTime()) {
+      return state;
+    }
+  }
+  return null;
+}
+
+export function readSession(projectRoot: string, sessionId: string): SessionState | null {
+  const file = statePath(projectRoot, sessionId);
+  if (!existsSync(file)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as SessionState;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSession(projectRoot: string, state: SessionState) {
+  const dir = sessionDir(projectRoot, state.id);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  // Atomic write: serialize to a sibling .tmp file, then rename.
+  // rename(2) is atomic on POSIX and NTFS when source and target are on the same filesystem.
+  // Protects against concurrent `grace afk tick` / `grace afk journal` / `grace afk increment`
+  // calls from the agent clobbering each other's updates.
+  const targetPath = statePath(projectRoot, state.id);
+  const tmpPath = `${targetPath}.${randomBytes(3).toString("hex")}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(state, null, 2));
+  renameSync(tmpPath, targetPath);
+}
+
+export type ActiveSessionCheck =
+  | { ok: true; session: SessionState; remainingMs: number }
+  | { ok: false; reason: "no-active-session" | "expired" | "stopped"; session: SessionState | null; remainingMs: number };
+
+export function checkActive(projectRoot: string, now: Date = new Date()): ActiveSessionCheck {
+  const session = findActiveSession(projectRoot, now);
+  if (!session) {
+    const latestId = listSessions(projectRoot).slice(-1)[0];
+    const latest = latestId ? readSession(projectRoot, latestId) : null;
+    if (latest && latest.status === "stopped") {
+      return { ok: false, reason: "stopped", session: latest, remainingMs: 0 };
+    }
+    if (latest && new Date(latest.expiresAt).getTime() <= now.getTime()) {
+      return { ok: false, reason: "expired", session: latest, remainingMs: 0 };
+    }
+    return { ok: false, reason: "no-active-session", session: latest, remainingMs: 0 };
+  }
+
+  const remainingMs = new Date(session.expiresAt).getTime() - now.getTime();
+  return { ok: true, session, remainingMs };
+}
+
+export function markStopped(
+  projectRoot: string,
+  sessionId: string,
+  reason: string,
+  now: Date = new Date(),
+): SessionState | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state) {
+    return null;
+  }
+  state.status = "stopped";
+  state.stopReason = reason;
+  state.lastTickAt = toIso(now);
+  writeSession(projectRoot, state);
+  return state;
+}
+
+export function markCompleted(projectRoot: string, sessionId: string, now: Date = new Date()): SessionState | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state) {
+    return null;
+  }
+  state.status = "completed";
+  state.lastTickAt = toIso(now);
+  writeSession(projectRoot, state);
+  return state;
+}
+
+export function incrementCounter(
+  projectRoot: string,
+  sessionId: string,
+  field: "commits" | "escalations" | "deferred",
+  now: Date = new Date(),
+): SessionState | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state) {
+    return null;
+  }
+  state[field] += 1;
+  state.lastTickAt = toIso(now);
+  writeSession(projectRoot, state);
+  return state;
+}
+
+export function updateLastTick(projectRoot: string, sessionId: string, now: Date = new Date()): SessionState | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state) {
+    return null;
+  }
+  state.lastTickAt = toIso(now);
+  writeSession(projectRoot, state);
+  return state;
+}
+
+// START_CONTRACT: addOpenAsk
+//   PURPOSE: Register a new outstanding ask on the session. Removes any stale answer for the same correlationId.
+//   INPUTS: { projectRoot, sessionId, ask: OpenAsk }
+//   OUTPUTS: SessionState | null
+//   SIDE_EFFECTS: Atomic write of state.json.
+// END_CONTRACT: addOpenAsk
+export function addOpenAsk(projectRoot: string, sessionId: string, ask: OpenAsk): SessionState | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state) {
+    return null;
+  }
+  state.openAsks = state.openAsks ?? [];
+  state.answers = state.answers ?? {};
+  state.openAsks = state.openAsks.filter((item) => item.correlationId !== ask.correlationId);
+  state.openAsks.push(ask);
+  delete state.answers[ask.correlationId];
+  writeSession(projectRoot, state);
+  return state;
+}
+
+// START_CONTRACT: recordAnswer
+//   PURPOSE: Persist an answer for an outstanding ask, removing it from openAsks.
+//   INPUTS: { projectRoot, sessionId, correlationId, answer: AnswerRecord }
+//   OUTPUTS: SessionState | null
+//   SIDE_EFFECTS: Atomic write of state.json.
+// END_CONTRACT: recordAnswer
+export function recordAnswer(
+  projectRoot: string,
+  sessionId: string,
+  correlationId: string,
+  answer: AnswerRecord,
+): SessionState | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state) {
+    return null;
+  }
+  state.openAsks = (state.openAsks ?? []).filter((item) => item.correlationId !== correlationId);
+  state.answers = state.answers ?? {};
+  state.answers[correlationId] = answer;
+  writeSession(projectRoot, state);
+  return state;
+}
+
+// START_CONTRACT: getAnswer
+//   PURPOSE: Look up a previously recorded answer without a network call.
+//   INPUTS: { projectRoot, sessionId, correlationId }
+//   OUTPUTS: AnswerRecord | null
+//   SIDE_EFFECTS: none (single file read)
+// END_CONTRACT: getAnswer
+export function getAnswer(
+  projectRoot: string,
+  sessionId: string,
+  correlationId: string,
+): AnswerRecord | null {
+  const state = readSession(projectRoot, sessionId);
+  if (!state || !state.answers) {
+    return null;
+  }
+  return state.answers[correlationId] ?? null;
+}
+
+// START_CONTRACT: listOpenAsks
+//   PURPOSE: Return the current list of outstanding asks for the session.
+//   INPUTS: { projectRoot, sessionId }
+//   OUTPUTS: OpenAsk[]
+//   SIDE_EFFECTS: none
+// END_CONTRACT: listOpenAsks
+export function listOpenAsks(projectRoot: string, sessionId: string): OpenAsk[] {
+  const state = readSession(projectRoot, sessionId);
+  return state?.openAsks ?? [];
+}
+
+export function formatRemaining(ms: number): string {
+  if (ms <= 0) {
+    return "0m";
+  }
+  const totalMinutes = Math.floor(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+  return `${hours}h ${minutes}m`;
+}
+
+export const EXIT_BUDGET_EXHAUSTED = 42;
+export const EXIT_NO_SESSION = 43;
+export const EXIT_SESSION_STOPPED = 44;
+
+export function resolveSessionPaths(projectRoot: string, sessionId: string) {
+  const dir = sessionDir(projectRoot, sessionId);
+  return {
+    dir,
+    statePath: statePath(projectRoot, sessionId),
+    decisionsPath: path.join(dir, "decisions.md"),
+    deferredPath: path.join(dir, "deferred.md"),
+    dashboardPath: path.join(dir, "dashboard.md"),
+  };
+}
+
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [3.7.0-grace-afk] Initial module. writeSession uses atomic rename to protect
+//                concurrent tick/journal/increment updates. newSessionId now includes 4 hex
+//                chars of randomness to avoid same-millisecond collisions.
+// END_CHANGE_SUMMARY

--- a/src/afk/telegram.ts
+++ b/src/afk/telegram.ts
@@ -1,0 +1,320 @@
+// FILE: src/afk/telegram.ts
+// VERSION: 1.0.0
+// START_MODULE_CONTRACT
+//   PURPOSE: Minimal Telegram Bot API transport for /afk one-way-door escalations.
+//   SCOPE: sendMessage + getUpdates + reply matching + answer classification. Plain text only (no markdown parsing — user-controlled fields flow through, injection must be impossible).
+//   DEPENDS: Web fetch API (injectable via `transport` param for tests)
+//   LINKS: M-AFK-TELEGRAM, https://core.telegram.org/bots/api
+//   ROLE: RUNTIME
+//   MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   TelegramTransport   - Injectable fetch-compatible function signature used by tests
+//   TelegramConfig             - Shape: { botToken, chatId }
+//   SendMessageResult          - Shape: { ok, messageId?, errorDescription? }
+//   IncomingReply              - Normalized update with chatId, optional fromMessageId, optional callbackQueryId
+//   InlineButton               - One inline-keyboard button: { text, callbackData }
+//   InlineKeyboard             - Matrix of InlineButton rows
+//   sendMessage                - POST to /sendMessage; accepts optional inline keyboard
+//   answerCallbackQuery        - POST to /answerCallbackQuery; dismisses the user's loading spinner
+//   editMessageRemoveKeyboard  - POST to /editMessageReplyMarkup with an empty keyboard
+//   fetchUpdates               - GET /getUpdates; parses message + callback_query; filters by chatId
+//   matchReply                 - Match a reply to a correlation id (reply_to, callback prefix, or token)
+//   classifyAnswer             - Strict classification: A-E / PROCEED / STOP / EVOLVE / DEFER / DETAILS / UNKNOWN
+// END_MODULE_MAP
+
+export type TelegramTransport = (url: string, init?: RequestInit) => Promise<Response>;
+
+export type TelegramConfig = {
+  botToken: string;
+  chatId: string;
+};
+
+export type SendMessageResult = {
+  ok: boolean;
+  messageId?: number;
+  errorDescription?: string;
+};
+
+export type IncomingReply = {
+  updateId: number;
+  text: string;
+  chatId: string;
+  fromMessageId?: number;
+  // When present, the reply came from an inline button press. The CLI must call
+  // answerCallbackQuery with this id to dismiss the loading spinner in the user's client.
+  callbackQueryId?: string;
+};
+
+export type InlineButton = {
+  text: string;
+  callbackData: string;
+};
+
+export type InlineKeyboard = InlineButton[][];
+
+function apiUrl(config: TelegramConfig, method: string) {
+  return `https://api.telegram.org/bot${config.botToken}/${method}`;
+}
+
+// START_CONTRACT: sendMessage
+//   PURPOSE: POST to /sendMessage with plain text and optional inline keyboard.
+//   INPUTS: { config, text, keyboard?, transport? }
+//   OUTPUTS: SendMessageResult { ok, messageId?, errorDescription? }
+//   SIDE_EFFECTS: HTTPS POST to Telegram Bot API.
+// END_CONTRACT: sendMessage
+export async function sendMessage(
+  config: TelegramConfig,
+  text: string,
+  keyboard?: InlineKeyboard | null,
+  transport: TelegramTransport = fetch,
+): Promise<SendMessageResult> {
+  // Plain text: user-controlled fields (titles, contexts from active .grace change bundles) flow
+  // into this transport. Previously parse_mode: "Markdown" permitted injection (clickable links,
+  // broken formatting, weaponized `]` / `[` pairs). We intentionally send plain text and rely
+  // on `buildAskMessage` to structure the payload with whitespace, not markdown syntax.
+  const payload: Record<string, unknown> = {
+    chat_id: config.chatId,
+    text,
+    disable_web_page_preview: true,
+  };
+  if (keyboard && keyboard.length > 0) {
+    payload.reply_markup = {
+      inline_keyboard: keyboard.map((row) =>
+        row.map((button) => ({ text: button.text, callback_data: button.callbackData })),
+      ),
+    };
+  }
+  const response = await transport(apiUrl(config, "sendMessage"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const body = (await response.json()) as {
+    ok: boolean;
+    result?: { message_id: number };
+    description?: string;
+  };
+
+  if (!body.ok) {
+    return { ok: false, errorDescription: body.description };
+  }
+
+  return { ok: true, messageId: body.result?.message_id };
+}
+
+// START_CONTRACT: answerCallbackQuery
+//   PURPOSE: Dismiss the loading spinner on an inline-button tap and optionally show a toast.
+//   INPUTS: { config, callbackQueryId, text?, transport? }
+//   OUTPUTS: { ok, errorDescription? }
+//   SIDE_EFFECTS: HTTPS POST to Telegram Bot API.
+// END_CONTRACT: answerCallbackQuery
+export async function answerCallbackQuery(
+  config: TelegramConfig,
+  callbackQueryId: string,
+  text: string | undefined,
+  transport: TelegramTransport = fetch,
+): Promise<{ ok: boolean; errorDescription?: string }> {
+  const payload: Record<string, unknown> = { callback_query_id: callbackQueryId };
+  if (text) {
+    payload.text = text;
+  }
+  const response = await transport(apiUrl(config, "answerCallbackQuery"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = (await response.json()) as { ok: boolean; description?: string };
+  return body.ok ? { ok: true } : { ok: false, errorDescription: body.description };
+}
+
+// START_CONTRACT: editMessageRemoveKeyboard
+//   PURPOSE: Strip the inline keyboard from a message once a button was pressed, so the user cannot tap a second answer.
+//   INPUTS: { config, messageId, transport? }
+//   OUTPUTS: { ok, errorDescription? }
+//   SIDE_EFFECTS: HTTPS POST to Telegram Bot API. Non-fatal on error.
+// END_CONTRACT: editMessageRemoveKeyboard
+export async function editMessageRemoveKeyboard(
+  config: TelegramConfig,
+  messageId: number,
+  transport: TelegramTransport = fetch,
+): Promise<{ ok: boolean; errorDescription?: string }> {
+  const response = await transport(apiUrl(config, "editMessageReplyMarkup"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      chat_id: config.chatId,
+      message_id: messageId,
+      reply_markup: { inline_keyboard: [] },
+    }),
+  });
+  const body = (await response.json()) as { ok: boolean; description?: string };
+  return body.ok ? { ok: true } : { ok: false, errorDescription: body.description };
+}
+
+export async function fetchUpdates(
+  config: TelegramConfig,
+  offset: number | null,
+  transport: TelegramTransport = fetch,
+): Promise<IncomingReply[]> {
+  const url = new URL(apiUrl(config, "getUpdates"));
+  if (offset !== null) {
+    url.searchParams.set("offset", String(offset));
+  }
+  url.searchParams.set("timeout", "0");
+  url.searchParams.set("allowed_updates", '["message","callback_query"]');
+
+  const response = await transport(url.toString());
+  const body = (await response.json()) as {
+    ok: boolean;
+    result?: Array<{
+      update_id: number;
+      message?: {
+        text?: string;
+        chat?: { id: number };
+        reply_to_message?: { message_id: number };
+      };
+      callback_query?: {
+        id: string;
+        data?: string;
+        message?: {
+          message_id: number;
+          chat?: { id: number };
+        };
+        from?: { id: number };
+      };
+    }>;
+  };
+
+  if (!body.ok || !Array.isArray(body.result)) {
+    return [];
+  }
+
+  const replies: IncomingReply[] = [];
+  for (const update of body.result) {
+    // START_BLOCK_PARSE_MESSAGE
+    if (update.message && typeof update.message.text === "string" && typeof update.message.chat?.id === "number") {
+      if (String(update.message.chat.id) === String(config.chatId)) {
+        replies.push({
+          updateId: update.update_id,
+          text: update.message.text.trim(),
+          chatId: String(update.message.chat.id),
+          fromMessageId: update.message.reply_to_message?.message_id,
+        });
+      }
+      continue;
+    }
+    // END_BLOCK_PARSE_MESSAGE
+
+    // START_BLOCK_PARSE_CALLBACK
+    const cb = update.callback_query;
+    if (!cb || typeof cb.data !== "string") {
+      continue;
+    }
+    const cbChatId = cb.message?.chat?.id;
+    if (typeof cbChatId !== "number" || String(cbChatId) !== String(config.chatId)) {
+      continue;
+    }
+    replies.push({
+      updateId: update.update_id,
+      text: cb.data.trim(),
+      chatId: String(cbChatId),
+      fromMessageId: cb.message?.message_id,
+      callbackQueryId: cb.id,
+    });
+    // END_BLOCK_PARSE_CALLBACK
+  }
+
+  return replies;
+}
+
+/**
+ * Match an incoming reply to an outstanding question.
+ *
+ * Priority:
+ * 1. Reply `reply_to_message` or callback-source message points at our correlation message id.
+ * 2. Callback data matches the `<correlationId>:<verb>` shape.
+ * 3. First whitespace-separated token of a text reply equals the correlation id.
+ * 4. Otherwise not matched.
+ */
+export function matchReply(reply: IncomingReply, correlationMessageId: number, correlationId: string) {
+  if (reply.fromMessageId === correlationMessageId) {
+    return true;
+  }
+  if (reply.callbackQueryId && reply.text.toLowerCase().startsWith(correlationId.toLowerCase() + ":")) {
+    return true;
+  }
+  const firstToken = reply.text.split(/\s+/)[0]?.toLowerCase() ?? "";
+  return firstToken === correlationId.toLowerCase();
+}
+
+/**
+ * Normalize an answer into a decision verb that /afk understands.
+ * Accepts: A/B/C/D/E, proceed, stop, evolve, defer (case-insensitive).
+ *
+ * Strict classification to prevent false positives on free-form text. Under the previous
+ * "any token matches" rule, replies like "do not STOP", "I think we should PROCEED", or
+ * "a cat" were all misclassified. The new rules:
+ *
+ *   1. Reject if the reply has more than 3 alphabetic tokens (free-form, not a short answer).
+ *   2. Reject if any negation token (NO/NOT/DONT/NEVER/CANCEL) appears — ambiguous.
+ *   3. Exactly one token must match the known verb/letter set.
+ *   4. Single-letter matches (A-E) must be the only token (avoid "a cat" -> A).
+ *
+ * When in doubt, return UNKNOWN so the agent falls back to `grace afk defer` rather than
+ * acting on a guessed classification for a one-way-door decision.
+ */
+const NEGATION_TOKENS = new Set(["NO", "NOT", "DONT", "NEVER", "CANCEL"]);
+const KNOWN_LETTERS = new Set(["A", "B", "C", "D", "E"]);
+const KNOWN_VERBS = new Set(["PROCEED", "STOP", "EVOLVE", "DEFER"]);
+// DETAILS is recognised but NOT terminal: callers must treat it as "show the breakdown and
+// keep polling". The classifier just returns it; the caller decides what to do.
+const META_VERBS = new Set(["DETAILS"]);
+
+export function classifyAnswer(text: string): { verb: string; raw: string; recognized: boolean } {
+  const trimmed = text.trim();
+  const reject = () => ({ verb: "UNKNOWN", raw: trimmed, recognized: false });
+
+  // Inline-button callback payloads arrive as "<corrId>:<verb>". If we detect the shape,
+  // classify the verb portion unambiguously and skip the fuzzy token-scan rules below.
+  const callbackMatch = /^[a-f0-9]{3,12}:([A-Za-z]+)$/.exec(trimmed);
+  if (callbackMatch) {
+    const verb = callbackMatch[1]!.toUpperCase();
+    if (KNOWN_LETTERS.has(verb) || KNOWN_VERBS.has(verb) || META_VERBS.has(verb)) {
+      return { verb, raw: trimmed, recognized: true };
+    }
+    return reject();
+  }
+
+  const tokens = trimmed
+    .split(/\s+/)
+    .map((token) => token.toUpperCase().replace(/[^A-Z]/g, ""))
+    .filter(Boolean);
+
+  if (tokens.length === 0 || tokens.length > 3) {
+    return reject();
+  }
+
+  const hasNegation = tokens.some((token) => NEGATION_TOKENS.has(token));
+  const matches = tokens.filter((token) => KNOWN_LETTERS.has(token) || KNOWN_VERBS.has(token));
+
+  if (hasNegation || matches.length !== 1) {
+    return reject();
+  }
+
+  const match = matches[0]!;
+  if (KNOWN_LETTERS.has(match) && tokens.length !== 1) {
+    return reject();
+  }
+
+  return { verb: match, raw: trimmed, recognized: true };
+}
+
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [3.7.0-grace-afk] Initial module. Plain text only (no parse_mode: Markdown) —
+//                title/context/options strings from development-plan.xml are user-controlled and
+//                must not be able to inject markdown links or break formatting. Strict
+//                classifyAnswer rejects multi-token, negated, or letter-in-free-text replies.
+// END_CHANGE_SUMMARY

--- a/src/afk/usage.ts
+++ b/src/afk/usage.ts
@@ -1,0 +1,150 @@
+// FILE: src/afk/usage.ts
+// VERSION: 1.0.0
+// START_MODULE_CONTRACT
+//   PURPOSE: Read Claude Code's cached usage snapshot produced by the statusline ($TMPDIR/claude/statusline-usage-cache.json).
+//     Provides 5-hour / 7-day utilization percentages and optional extra-credit (dollar) figures that `grace afk` surfaces in reports and `done` notifications.
+//   SCOPE: File read only. No network calls. No refresh. Cache is refreshed by the statusline on its own 60-second cycle; grace afk just consumes it.
+//   DEPENDS: node:fs, node:os, node:path
+//   LINKS: M-AFK-USAGE, skills/grace/grace-afk/SKILL.md
+//   ROLE: RUNTIME
+//   MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   UsageSnapshot    - Typed shape: fiveHourPct, sevenDayPct, extra? { used, limit, currency, pct }, ageSeconds
+//   UsageExtra       - Shape: { usedCredits, monthlyLimit, currency, pct }
+//   readUsage        - Read and parse the cache; returns null when absent or malformed
+//   renderUsageLine  - Human-readable one-line summary (for `grace afk report` and done notifications)
+//   cachePath        - Resolve the canonical cache path on the current platform
+// END_MODULE_MAP
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type UsageExtra = {
+  usedCredits: number;
+  monthlyLimit: number;
+  currency: string;
+  pct: number;
+};
+
+export type UsageSnapshot = {
+  fiveHourPct: number;
+  sevenDayPct: number;
+  fiveHourResetsAt: string | null;
+  sevenDayResetsAt: string | null;
+  extra: UsageExtra | null;
+  ageSeconds: number;
+  source: string;
+};
+
+// START_CONTRACT: cachePath
+//   PURPOSE: Resolve the statusline's usage cache path. Claude Code's statusline writes to
+//     `${os.tmpdir()}/claude/statusline-usage-cache.json` on all platforms (Git-Bash /tmp on Windows
+//     maps to the same AppData\Local\Temp directory that os.tmpdir() returns).
+//   INPUTS: none
+//   OUTPUTS: string (absolute path)
+//   SIDE_EFFECTS: none
+// END_CONTRACT: cachePath
+export function cachePath(): string {
+  return path.join(os.tmpdir(), "claude", "statusline-usage-cache.json");
+}
+
+// START_CONTRACT: readUsage
+//   PURPOSE: Return the most recent usage snapshot, or null if the cache is missing/malformed.
+//   INPUTS: { filePath?: string - optional override for tests }
+//   OUTPUTS: UsageSnapshot | null
+//   SIDE_EFFECTS: Reads the file system (single file).
+// END_CONTRACT: readUsage
+export function readUsage(filePath: string = cachePath()): UsageSnapshot | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  let body: any;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const fiveHourPct = pickPct(body?.five_hour?.utilization);
+  const sevenDayPct = pickPct(body?.seven_day?.utilization);
+  if (fiveHourPct === null && sevenDayPct === null) {
+    return null;
+  }
+
+  let ageSeconds = 0;
+  try {
+    ageSeconds = Math.max(0, Math.round((Date.now() - statSync(filePath).mtimeMs) / 1000));
+  } catch {
+    ageSeconds = 0;
+  }
+
+  let extra: UsageExtra | null = null;
+  const extraBlock = body?.extra_usage;
+  if (extraBlock && extraBlock.is_enabled) {
+    // Cents -> dollars (the API returns hundredths of currency units).
+    const usedCredits = (Number(extraBlock.used_credits) || 0) / 100;
+    const monthlyLimit = (Number(extraBlock.monthly_limit) || 0) / 100;
+    const pct = Number(extraBlock.utilization) || 0;
+    extra = {
+      usedCredits,
+      monthlyLimit,
+      currency: typeof extraBlock.currency === "string" ? extraBlock.currency : "USD",
+      pct,
+    };
+  }
+
+  return {
+    fiveHourPct: fiveHourPct ?? 0,
+    sevenDayPct: sevenDayPct ?? 0,
+    fiveHourResetsAt: typeof body?.five_hour?.resets_at === "string" ? body.five_hour.resets_at : null,
+    sevenDayResetsAt: typeof body?.seven_day?.resets_at === "string" ? body.seven_day.resets_at : null,
+    extra,
+    ageSeconds,
+    source: filePath,
+  };
+}
+
+function pickPct(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.round(value);
+}
+
+// START_CONTRACT: renderUsageLine
+//   PURPOSE: Produce a single-line summary suitable for Telegram / reports.
+//     Example: "5h 7% · 7d 21% · $14.68/60.00 (24%) · cache age 5s"
+//   INPUTS: { snapshot: UsageSnapshot | null, fallback?: string }
+//   OUTPUTS: string (one line, no control characters)
+//   SIDE_EFFECTS: none
+// END_CONTRACT: renderUsageLine
+export function renderUsageLine(snapshot: UsageSnapshot | null, fallback = "usage: (statusline cache unavailable)"): string {
+  if (!snapshot) {
+    return fallback;
+  }
+  const parts: string[] = [];
+  parts.push(`5h ${snapshot.fiveHourPct}%`);
+  parts.push(`7d ${snapshot.sevenDayPct}%`);
+  if (snapshot.extra) {
+    const dollars = snapshot.extra.usedCredits.toFixed(2);
+    const limit = snapshot.extra.monthlyLimit.toFixed(2);
+    const pct = Math.round(snapshot.extra.pct);
+    const sign = snapshot.extra.currency === "USD" ? "$" : snapshot.extra.currency + " ";
+    parts.push(`${sign}${dollars}/${limit} (${pct}%)`);
+  }
+  parts.push(`cache age ${snapshot.ageSeconds}s`);
+  return parts.join(" · ");
+}
+
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [3.7.0-grace-evolve] Initial. Read-only consumer of the Claude Code statusline usage cache.
+// END_CHANGE_SUMMARY

--- a/src/grace-afk.ts
+++ b/src/grace-afk.ts
@@ -1,0 +1,1131 @@
+// FILE: src/grace-afk.ts
+// VERSION: 1.0.0
+// START_MODULE_CONTRACT
+//   PURPOSE: citty subcommand `grace afk` — autonomous-harness start / tick / ask / check / journal / defer / increment / report / stop.
+//   SCOPE: CLI wiring + I/O only. Business logic lives in src/afk/*; this module orchestrates them and enforces the active-session gate.
+//   DEPENDS: citty, node:crypto, node:path, ./afk/config, ./afk/journal, ./afk/session, ./afk/telegram
+//   LINKS: M-CLI-AFK, skills/grace/grace-afk/SKILL.md
+//   ROLE: RUNTIME
+//   MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+//
+// START_MODULE_MAP
+//   afkCommand           - Root citty command; 10 subcommands including `done` (end-of-step notify+ask)
+//   buildAskMessage      - Format the Telegram ask payload (plain text, no markdown)
+//   buildAskKeyboard     - Construct inline keyboard: letter row + meta row + optional [Details]
+//   buildDetailsMessage  - Render SWOT breakdown (pros/cons/opportunities/risks) per option
+//   buildDoneContext     - Compose the context line for `grace afk done` (elapsed + commits + usage)
+//   parseDetailsArg      - Parse the --details CLI string into a Map of OptionDetail
+//   projectNameFromPath  - Convert kebab/snake basename to Title Case
+//   OptionDetail         - Shape: { id, pros, cons, opportunities, risks }
+// END_MODULE_MAP
+
+import { defineCommand } from "citty";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+import { getMaxEscalations, getTelegram, loadAfkConfig } from "./afk/config";
+import { DECISION_CLASSES, appendDecision, appendDeferred, isDecisionClass, readJournal } from "./afk/journal";
+import {
+  EXIT_BUDGET_EXHAUSTED,
+  EXIT_NO_SESSION,
+  EXIT_SESSION_STOPPED,
+  addOpenAsk,
+  checkActive,
+  createSession,
+  formatRemaining,
+  getAnswer,
+  incrementCounter,
+  listOpenAsks,
+  markCompleted,
+  markStopped,
+  readSession,
+  recordAnswer,
+  resolveSessionPaths,
+  updateLastTick,
+} from "./afk/session";
+import {
+  answerCallbackQuery,
+  classifyAnswer,
+  editMessageRemoveKeyboard,
+  fetchUpdates,
+  matchReply,
+  sendMessage,
+  type InlineKeyboard,
+} from "./afk/telegram";
+import { readUsage, renderUsageLine } from "./afk/usage";
+
+const EXIT_BAD_ARGS = 2;
+const EXIT_TELEGRAM_FAILURE = 45;
+const EXIT_CONFIG_MISSING = 46;
+
+// START_CONTRACT: drainPendingCallbacks
+//   PURPOSE: Fetch one batch of Telegram updates, match them against the session's openAsks,
+//     ack any inline-button taps, strip their keyboards, and record the answers into state.json.
+//     Safe to call at any cadence — ticks, check, ask --wait, CI smokes all share this.
+//   INPUTS: { projectRoot, sessionId, telegram }
+//   OUTPUTS: { processed: Array<{ correlationId, answer }> }
+//   SIDE_EFFECTS: HTTPS calls to getUpdates / answerCallbackQuery / editMessageReplyMarkup;
+//     atomic writes to state.json via recordAnswer.
+// END_CONTRACT: drainPendingCallbacks
+async function drainPendingCallbacks(
+  projectRoot: string,
+  sessionId: string,
+  telegram: { botToken: string; chatId: string },
+): Promise<Array<{ correlationId: string; verb: string; recognized: boolean; raw: string; source: "button" | "text" }>> {
+  const asks = listOpenAsks(projectRoot, sessionId);
+  if (asks.length === 0) {
+    return [];
+  }
+
+  let replies: Awaited<ReturnType<typeof fetchUpdates>>;
+  try {
+    replies = await fetchUpdates(telegram, null);
+  } catch (error) {
+    process.stderr.write(`drainPendingCallbacks: fetchUpdates failed — ${error instanceof Error ? error.message : String(error)}\n`);
+    return [];
+  }
+
+  const processed: Array<{ correlationId: string; verb: string; recognized: boolean; raw: string; source: "button" | "text" }> = [];
+  for (const reply of replies) {
+    const match = asks.find((ask) => matchReply(reply, ask.messageId ?? 0, ask.correlationId));
+    if (!match) {
+      continue;
+    }
+    const classified = classifyAnswer(reply.text);
+    if (classified.recognized && classified.verb === "DETAILS") {
+      // DETAILS is non-terminal and carries no spec details at drain-time, so ack only.
+      if (reply.callbackQueryId) {
+        try {
+          await answerCallbackQuery(telegram, reply.callbackQueryId, "Details were sent when the ask was first opened.");
+        } catch {
+          /* non-fatal */
+        }
+      }
+      continue;
+    }
+
+    const source: "button" | "text" = reply.callbackQueryId ? "button" : "text";
+
+    if (reply.callbackQueryId) {
+      try {
+        await answerCallbackQuery(
+          telegram,
+          reply.callbackQueryId,
+          classified.recognized ? `Received: ${classified.verb}` : undefined,
+        );
+      } catch {
+        /* non-fatal */
+      }
+      if (match.messageId) {
+        try {
+          await editMessageRemoveKeyboard(telegram, match.messageId);
+        } catch {
+          /* non-fatal */
+        }
+      }
+    }
+
+    recordAnswer(projectRoot, sessionId, match.correlationId, {
+      verb: classified.verb,
+      raw: classified.raw,
+      source,
+      recognized: classified.recognized,
+      receivedAt: new Date().toISOString(),
+    });
+    processed.push({ correlationId: match.correlationId, verb: classified.verb, recognized: classified.recognized, raw: classified.raw, source });
+  }
+  return processed;
+}
+
+function toPath(value: unknown, fallback = ".") {
+  return path.resolve(String(value ?? fallback));
+}
+
+function shortCorrelationId() {
+  return randomBytes(3).toString("hex");
+}
+
+/**
+ * Enforce the active-session guard. Any `grace afk` subcommand (except `start`)
+ * must call this first. The CLI — NOT the agent — decides when to stop.
+ */
+function enforceActive(projectRoot: string, allowStopped = false): { sessionId: string; remainingMs: number } {
+  const check = checkActive(projectRoot);
+  if (check.ok) {
+    return { sessionId: check.session.id, remainingMs: check.remainingMs };
+  }
+
+  if (check.reason === "no-active-session") {
+    process.stderr.write("grace-afk: no active session. Run `grace afk start <hours>` first.\n");
+    process.exit(EXIT_NO_SESSION);
+  }
+  if (check.reason === "expired") {
+    process.stderr.write(
+      `grace-afk: session ${check.session?.id ?? "?"} expired at ${check.session?.expiresAt ?? "?"}. ` +
+        "Budget exhausted — agent must commit final state and stop.\n",
+    );
+    process.exit(EXIT_BUDGET_EXHAUSTED);
+  }
+  if (check.reason === "stopped") {
+    if (allowStopped) {
+      return { sessionId: check.session!.id, remainingMs: 0 };
+    }
+    process.stderr.write(
+      `grace-afk: session ${check.session?.id ?? "?"} was stopped (reason: ${
+        check.session?.stopReason ?? "unknown"
+      }).\n`,
+    );
+    process.exit(EXIT_SESSION_STOPPED);
+  }
+
+  process.exit(EXIT_NO_SESSION);
+}
+
+export const afkCommand = defineCommand({
+  meta: {
+    name: "afk",
+    description:
+      "Autonomous harness. CLI enforces session time budget; agent polls `grace afk tick` between steps.",
+  },
+  subCommands: {
+    start: defineCommand({
+      meta: {
+        name: "start",
+        description: "Start a new /afk session. Creates docs/afk-sessions/<id>/ and a state.json with expiresAt.",
+      },
+      args: {
+        hours: { type: "positional", description: "Hours of autonomy (0 < h <= 24)", default: "2" },
+        budgetPercent: { type: "positional", required: false, description: "Optional weekly-token budget cap (%)" },
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        checkpoint: { type: "string", description: "Checkpoint interval in minutes (5-180)", default: "30" },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const hours = Number(context.args.hours ?? 2);
+        const budgetRaw = context.args.budgetPercent;
+        const budgetPercent = budgetRaw === undefined || budgetRaw === "" ? null : Number(budgetRaw);
+        const checkpointMinutes = Number(context.args.checkpoint ?? 30);
+
+        const state = createSession(
+          projectRoot,
+          { hours, budgetPercent, checkpointMinutes },
+          new Date(),
+        );
+
+        const lines = [
+          `Started /afk session ${state.id}`,
+          `  hours:       ${state.hours}`,
+          `  budget%:     ${state.budgetPercent === null ? "default" : state.budgetPercent + "%"}`,
+          `  checkpoint:  ${state.checkpointMinutes}m`,
+          `  expires:     ${state.expiresAt}`,
+          `  journal:     docs/afk-sessions/${state.id}/`,
+          "",
+          "Agent protocol:",
+          "  - Between steps, run `grace afk tick --path .` — non-zero exit means session over.",
+          "  - For uncertain one-way-door decisions: `grace afk ask --title ... --options ...`.",
+          "  - For decisions deferred to human: `grace afk defer --question ... --context ...`.",
+          "  - Record every decision: `grace afk journal --class ... --title ... --rationale ... --outcome ...`.",
+          "  - On exit/expire: `grace afk report` emits the dashboard.",
+        ];
+        process.stdout.write(lines.join("\n") + "\n");
+      },
+    }),
+
+    tick: defineCommand({
+      meta: {
+        name: "tick",
+        description:
+          "CLI-side budget enforcement. Exits non-zero if the session is expired, stopped, or missing. Agent must call between steps.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const { sessionId, remainingMs } = enforceActive(projectRoot);
+        updateLastTick(projectRoot, sessionId);
+
+        // Drain any user taps made since the last tick. This is what makes `ask` non-blocking:
+        // the user can reply at any time, whether 10s or 10h later, and the next tick picks it up.
+        const { config } = loadAfkConfig(projectRoot);
+        const telegram = getTelegram(config);
+        let newAnswers: Array<{ correlationId: string; verb: string; source: "button" | "text" }> = [];
+        if (telegram) {
+          newAnswers = (await drainPendingCallbacks(projectRoot, sessionId, telegram)).map((r) => ({
+            correlationId: r.correlationId,
+            verb: r.verb,
+            source: r.source,
+          }));
+        }
+
+        const openCount = listOpenAsks(projectRoot, sessionId).length;
+        const lines = [`session=${sessionId} remaining=${formatRemaining(remainingMs)} status=active openAsks=${openCount}`];
+        for (const answer of newAnswers) {
+          lines.push(`answered: ${answer.correlationId} = ${answer.verb} (${answer.source})`);
+        }
+        process.stdout.write(lines.join("\n") + "\n");
+      },
+    }),
+
+    ask: defineCommand({
+      meta: {
+        name: "ask",
+        description:
+          "Send a Telegram escalation for a one-way-door decision. Prints the correlation id the agent must use to poll for a reply.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        title: { type: "string", required: true, description: "Short decision title" },
+        context: { type: "string", required: true, description: "One-sentence situation description" },
+        options: {
+          type: "string",
+          required: true,
+          description: 'Options as "A:label|B:label" or "A:label;B:label" (semicolon is safer on Windows shells)',
+        },
+        mypick: { type: "string", description: "Letter you currently favor (A/B/...)", default: "" },
+        confidence: { type: "string", description: "Confidence percent (0-100)", default: "50" },
+        wait: {
+          type: "string",
+          description:
+            "Block for up to N seconds waiting for a reply; ack inline-button taps immediately (default: 0 = return right after send).",
+          default: "0",
+        },
+        details: {
+          type: "string",
+          description:
+            'SWOT breakdown per option: "A|pros|cons|opportunities|risks;B|...". When present, the keyboard gains a [Details] button that sends a follow-up breakdown message without cancelling the ask.',
+          default: "",
+        },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const { sessionId } = enforceActive(projectRoot);
+
+        const { config, error } = loadAfkConfig(projectRoot);
+        const telegram = getTelegram(config);
+        if (!telegram) {
+          process.stderr.write(
+            `grace afk ask: Telegram not configured (${error ?? "missing telegram.botToken/chatId"}). ` +
+              "Agent MUST fall back to `grace afk defer` for one-way-door decisions.\n",
+          );
+          process.exitCode = EXIT_CONFIG_MISSING;
+          return;
+        }
+
+        const session = readSession(projectRoot, sessionId);
+        const maxEscalations = getMaxEscalations(config);
+        if (session && session.escalations >= maxEscalations) {
+          process.stderr.write(
+            `grace afk ask: max ${maxEscalations} escalations already sent this session. ` +
+              "Agent MUST defer remaining one-way-door decisions.\n",
+          );
+          process.exitCode = EXIT_BAD_ARGS;
+          return;
+        }
+
+        const correlationId = shortCorrelationId();
+        // Accept both "|" and ";" as separators: cmd.exe on Windows interprets unquoted "|" as
+        // a pipe even when the whole argument is quoted, because bun.cmd is a shim that re-parses.
+        const optionsList = String(context.args.options)
+          .split(/[|;]/)
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+
+        const text = buildAskMessage({
+          correlationId,
+          sessionId,
+          projectName: projectNameFromPath(projectRoot),
+          title: String(context.args.title),
+          context: String(context.args.context),
+          options: optionsList,
+          myPick: String(context.args.mypick),
+          confidence: String(context.args.confidence),
+        });
+
+        const detailsMap = parseDetailsArg(String(context.args.details ?? ""));
+        const hasDetails = detailsMap.size > 0;
+        const keyboard = buildAskKeyboard(correlationId, optionsList, hasDetails);
+        const result = await sendMessage(telegram, text, keyboard);
+        if (!result.ok) {
+          process.stderr.write(
+            `grace afk ask: Telegram sendMessage failed (${result.errorDescription ?? "unknown"}).\n`,
+          );
+          process.exitCode = EXIT_TELEGRAM_FAILURE;
+          return;
+        }
+
+        incrementCounter(projectRoot, sessionId, "escalations");
+
+        // Fire-and-forget by default: register the ask in state.openAsks, return immediately.
+        // Subsequent `grace afk tick` calls will drain any taps and record answers. The user can
+        // reply whenever (minutes, hours) — the next tick picks it up.
+        addOpenAsk(projectRoot, sessionId, {
+          correlationId,
+          messageId: result.messageId ?? null,
+          sentAt: new Date().toISOString(),
+          title: String(context.args.title),
+        });
+
+        const waitSeconds = Number(context.args.wait ?? "0");
+        if (!Number.isFinite(waitSeconds) || waitSeconds <= 0) {
+          process.stdout.write(
+            JSON.stringify({ correlationId, messageId: result.messageId, sessionId, status: "sent" }, null, 2) + "\n",
+          );
+          return;
+        }
+
+        // Optional blocking poll for interactive use (e.g. smoke tests). Still uses the shared
+        // drain helper so button taps are handled identically in either mode. Also sends the
+        // SWOT details follow-up when DETAILS is tapped and keeps polling.
+        const deadline = Date.now() + Math.min(waitSeconds, 86400) * 1000; // hard cap 24h
+        const projectName = projectNameFromPath(projectRoot);
+        while (Date.now() < deadline) {
+          // The shared drain path handles ack + keyboard removal + recordAnswer atomically.
+          // DETAILS is non-terminal there (ack only), so we re-send the SWOT follow-up here
+          // when we detect a DETAILS-kind reply during this blocking window.
+          let replies: Awaited<ReturnType<typeof fetchUpdates>>;
+          try {
+            replies = await fetchUpdates(telegram, null);
+          } catch {
+            replies = [];
+          }
+          for (const reply of replies) {
+            if (!matchReply(reply, result.messageId ?? 0, correlationId)) {
+              continue;
+            }
+            const classified = classifyAnswer(reply.text);
+            if (classified.recognized && classified.verb === "DETAILS") {
+              if (reply.callbackQueryId) {
+                try {
+                  await answerCallbackQuery(telegram, reply.callbackQueryId, "Sending details…");
+                } catch {
+                  /* non-fatal */
+                }
+              }
+              if (hasDetails) {
+                try {
+                  await sendMessage(
+                    telegram,
+                    buildDetailsMessage({ projectName, correlationId, options: optionsList, details: detailsMap }),
+                    null,
+                  );
+                } catch {
+                  /* non-fatal */
+                }
+              }
+              continue;
+            }
+            // Non-DETAILS → delegate the ack + keyboard strip + recordAnswer to the shared drain.
+            await drainPendingCallbacks(projectRoot, sessionId, telegram);
+            const answer = getAnswer(projectRoot, sessionId, correlationId);
+            if (answer) {
+              process.stdout.write(
+                JSON.stringify(
+                  {
+                    correlationId,
+                    messageId: result.messageId,
+                    sessionId,
+                    status: answer.recognized ? "answered" : "unrecognized",
+                    verb: answer.verb,
+                    raw: answer.raw,
+                    source: answer.source,
+                  },
+                  null,
+                  2,
+                ) + "\n",
+              );
+              return;
+            }
+          }
+
+          // Also poll state.json in case a concurrent `tick` already recorded the answer.
+          const cached = getAnswer(projectRoot, sessionId, correlationId);
+          if (cached) {
+            process.stdout.write(
+              JSON.stringify(
+                {
+                  correlationId,
+                  messageId: result.messageId,
+                  sessionId,
+                  status: cached.recognized ? "answered" : "unrecognized",
+                  verb: cached.verb,
+                  raw: cached.raw,
+                  source: cached.source,
+                },
+                null,
+                2,
+              ) + "\n",
+            );
+            return;
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
+
+        process.stdout.write(
+          JSON.stringify(
+            {
+              correlationId,
+              messageId: result.messageId,
+              sessionId,
+              status: "pending",
+              waitedSeconds: waitSeconds,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+      },
+    }),
+
+    check: defineCommand({
+      meta: {
+        name: "check",
+        description:
+          "Report the answer for a correlation id. Reads the cached answer from state.json first (populated by `tick` on each call); falls back to a live Telegram poll only if the session has a config and the answer is still pending.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        correlation: { type: "string", required: true, description: "Correlation id returned by `ask`" },
+        messageid: {
+          type: "string",
+          description: "Telegram message id returned by `ask` (only used for live poll fallback)",
+          default: "0",
+        },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const { sessionId } = enforceActive(projectRoot);
+        const correlationId = String(context.args.correlation);
+
+        // Step 1: cached answer — free, no network.
+        const cached = getAnswer(projectRoot, sessionId, correlationId);
+        if (cached) {
+          process.stdout.write(
+            JSON.stringify(
+              {
+                status: cached.recognized ? "answered" : "unrecognized",
+                verb: cached.verb,
+                raw: cached.raw,
+                source: cached.source,
+                receivedAt: cached.receivedAt,
+              },
+              null,
+              2,
+            ) + "\n",
+          );
+          return;
+        }
+
+        // Step 2: opportunistically drain new callbacks and re-check the cache. Matches the
+        // semantics of `tick` but scoped to one correlation id.
+        const { config } = loadAfkConfig(projectRoot);
+        const telegram = getTelegram(config);
+        if (telegram) {
+          await drainPendingCallbacks(projectRoot, sessionId, telegram);
+          const fresh = getAnswer(projectRoot, sessionId, correlationId);
+          if (fresh) {
+            process.stdout.write(
+              JSON.stringify(
+                {
+                  status: fresh.recognized ? "answered" : "unrecognized",
+                  verb: fresh.verb,
+                  raw: fresh.raw,
+                  source: fresh.source,
+                  receivedAt: fresh.receivedAt,
+                },
+                null,
+                2,
+              ) + "\n",
+            );
+            return;
+          }
+        }
+
+        process.stdout.write(JSON.stringify({ status: "pending" }) + "\n");
+      },
+    }),
+
+    journal: defineCommand({
+      meta: {
+        name: "journal",
+        description: "Append a decision entry to the active session's decisions.md.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        class: {
+          type: "string",
+          required: true,
+          description: `Decision class. One of: ${DECISION_CLASSES.join(", ")}`,
+        },
+        title: { type: "string", required: true, description: "Short title" },
+        // `--context` is the canonical name. `--contextLine` accepted as an alias for back-compat.
+        context: { type: "string", description: "Context / plan step reference", default: "-" },
+        contextLine: { type: "string", description: "Alias for --context", default: "" },
+        options: { type: "string", description: "Pipe-separated options considered", default: "" },
+        chosen: { type: "string", description: "Chosen option", default: "" },
+        rationale: { type: "string", required: true, description: "1-2 sentence rationale" },
+        outcome: { type: "string", required: true, description: "Commit hash, deferred ref, etc." },
+      },
+      async run(ctx) {
+        const projectRoot = toPath(ctx.args.path);
+        const { sessionId } = enforceActive(projectRoot);
+        const paths = resolveSessionPaths(projectRoot, sessionId);
+
+        const klassArg = String(ctx.args.class);
+        if (!isDecisionClass(klassArg)) {
+          process.stderr.write(
+            `grace afk journal: invalid --class "${klassArg}". Allowed: ${DECISION_CLASSES.join(", ")}\n`,
+          );
+          process.exit(EXIT_BAD_ARGS);
+        }
+
+        const contextValue = String(ctx.args.context || ctx.args.contextLine || "-");
+
+        appendDecision(paths.decisionsPath, {
+          timestamp: new Date().toISOString(),
+          klass: klassArg,
+          title: String(ctx.args.title),
+          context: contextValue,
+          optionsConsidered: String(ctx.args.options)
+            .split("|")
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+          chosen: String(ctx.args.chosen) || undefined,
+          rationale: String(ctx.args.rationale),
+          outcome: String(ctx.args.outcome),
+        });
+
+        process.stdout.write(`appended to ${paths.decisionsPath}\n`);
+      },
+    }),
+
+    defer: defineCommand({
+      meta: {
+        name: "defer",
+        description: "Record a question that requires human attention on return.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        question: { type: "string", required: true, description: "The question for the human" },
+        // `--context` is the canonical name. `--contextLine` accepted as an alias for back-compat.
+        context: { type: "string", description: "Context reference (step / file / decision)", default: "" },
+        contextLine: { type: "string", description: "Alias for --context", default: "" },
+        suggestion: { type: "string", description: "Optional recommended default", default: "" },
+      },
+      async run(ctx) {
+        const projectRoot = toPath(ctx.args.path);
+        const { sessionId } = enforceActive(projectRoot);
+        const paths = resolveSessionPaths(projectRoot, sessionId);
+
+        const contextValue = String(ctx.args.context || ctx.args.contextLine || "");
+        if (!contextValue) {
+          process.stderr.write("grace afk defer: --context is required (alias: --contextLine)\n");
+          process.exit(EXIT_BAD_ARGS);
+        }
+
+        appendDeferred(paths.deferredPath, {
+          timestamp: new Date().toISOString(),
+          question: String(ctx.args.question),
+          context: contextValue,
+          suggestion: String(ctx.args.suggestion) || undefined,
+        });
+        incrementCounter(projectRoot, sessionId, "deferred");
+
+        process.stdout.write(`appended to ${paths.deferredPath}\n`);
+      },
+    }),
+
+    report: defineCommand({
+      meta: {
+        name: "report",
+        description: "Emit the return dashboard. Marks the session completed unless --keep-active is passed.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        keepActive: { type: "boolean", description: "Do not mark session completed", default: false },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const check = checkActive(projectRoot);
+        const session = check.session;
+        if (!session) {
+          process.stderr.write("grace afk report: no session found.\n");
+          process.exit(EXIT_NO_SESSION);
+        }
+
+        const paths = resolveSessionPaths(projectRoot, session.id);
+        const deferred = readJournal(paths.deferredPath);
+        const deferredCount = deferred.split("\n").filter((line) => line.trim().startsWith("- [")).length;
+
+        const usage = readUsage();
+        const lines = [
+          `/afk session ${session.id} — report`,
+          `Status:       ${session.status}`,
+          `Budget:       hours=${session.hours}  budget%=${session.budgetPercent ?? "default"}`,
+          `Started:      ${session.createdAt}`,
+          `Expires:      ${session.expiresAt}`,
+          `Last tick:    ${session.lastTickAt ?? "never"}`,
+          `Commits:      ${session.commits}`,
+          `Escalations:  ${session.escalations}`,
+          `Deferred:     ${deferredCount} (see ${path.relative(projectRoot, paths.deferredPath)})`,
+          `Stop reason:  ${session.stopReason ?? "-"}`,
+          `Journal:      ${path.relative(projectRoot, paths.decisionsPath)}`,
+          `Usage:        ${renderUsageLine(usage)}`,
+        ];
+        process.stdout.write(lines.join("\n") + "\n");
+
+        if (!Boolean(context.args.keepActive) && session.status === "active") {
+          markCompleted(projectRoot, session.id);
+        }
+      },
+    }),
+
+    done: defineCommand({
+      meta: {
+        name: "done",
+        description:
+          "Notify the user that a logical step finished and ask what to do next. Auto-fills context with elapsed time, commit/escalation/deferred counters, and current usage (5h/7d/$).",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        title: {
+          type: "string",
+          description: "Short title (default: auto from project name)",
+          default: "",
+        },
+        next: {
+          type: "string",
+          required: true,
+          description:
+            'Next-step candidates as "A:label;B:label;..." (semicolon-separated, same syntax as `ask --options`).',
+        },
+        details: {
+          type: "string",
+          description:
+            'Optional SWOT breakdown per candidate: "A|pros|cons|opportunities|risks;B|..."',
+          default: "",
+        },
+        mypick: {
+          type: "string",
+          description: "Recommended next step (letter)",
+          default: "",
+        },
+        confidence: { type: "string", description: "Confidence percent (0-100)", default: "60" },
+        wait: { type: "string", description: "Block-and-poll for up to N seconds", default: "180" },
+      },
+      async run(ctx) {
+        const projectRoot = toPath(ctx.args.path);
+        const { sessionId } = enforceActive(projectRoot);
+        const session = readSession(projectRoot, sessionId);
+        if (!session) {
+          process.stderr.write("grace afk done: session not found after tick.\n");
+          process.exitCode = EXIT_NO_SESSION;
+          return;
+        }
+
+        const usage = readUsage();
+        const usageLine = renderUsageLine(usage, "usage: unavailable");
+        const context = buildDoneContext({
+          sessionStartIso: session.createdAt,
+          now: new Date(),
+          commits: session.commits,
+          escalations: session.escalations,
+          deferred: session.deferred,
+          usageLine,
+        });
+
+        const projectName = projectNameFromPath(projectRoot);
+        const title = String(ctx.args.title) || `${projectName}: step done — what next?`;
+
+        // Delegate by re-invoking the same runtime path as `ask`. We inline the minimal flow
+        // instead of calling the `ask` subcommand object so that we can re-use the details/keyboard
+        // helpers and share the same wait-loop behaviour.
+        const { config, error } = loadAfkConfig(projectRoot);
+        const telegram = getTelegram(config);
+        if (!telegram) {
+          process.stderr.write(
+            `grace afk done: Telegram not configured (${error ?? "missing telegram.botToken/chatId"}). ` +
+              "Cannot notify the user. Run `grace afk defer` with the summary instead.\n",
+          );
+          process.exitCode = EXIT_CONFIG_MISSING;
+          return;
+        }
+
+        const maxEscalations = getMaxEscalations(config);
+        if (session.escalations >= maxEscalations) {
+          process.stderr.write(
+            `grace afk done: max ${maxEscalations} escalations already sent this session. Use grace afk defer.\n`,
+          );
+          process.exitCode = EXIT_BAD_ARGS;
+          return;
+        }
+
+        const correlationId = shortCorrelationId();
+        const optionsList = String(ctx.args.next)
+          .split(/[|;]/)
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+
+        const text = buildAskMessage({
+          correlationId,
+          sessionId,
+          projectName,
+          title,
+          context,
+          options: optionsList,
+          myPick: String(ctx.args.mypick),
+          confidence: String(ctx.args.confidence),
+        });
+
+        const detailsMap = parseDetailsArg(String(ctx.args.details ?? ""));
+        const hasDetails = detailsMap.size > 0;
+        const keyboard = buildAskKeyboard(correlationId, optionsList, hasDetails);
+        const result = await sendMessage(telegram, text, keyboard);
+        if (!result.ok) {
+          process.stderr.write(
+            `grace afk done: Telegram sendMessage failed (${result.errorDescription ?? "unknown"}).\n`,
+          );
+          process.exitCode = EXIT_TELEGRAM_FAILURE;
+          return;
+        }
+        incrementCounter(projectRoot, sessionId, "escalations");
+
+        const waitSeconds = Number(ctx.args.wait ?? "180");
+        if (!Number.isFinite(waitSeconds) || waitSeconds <= 0) {
+          process.stdout.write(
+            JSON.stringify({ correlationId, messageId: result.messageId, sessionId, usageLine }, null, 2) + "\n",
+          );
+          return;
+        }
+
+        const deadline = Date.now() + Math.min(waitSeconds, 600) * 1000;
+        let offset: number | null = null;
+        while (Date.now() < deadline) {
+          const replies = await fetchUpdates(telegram, offset);
+          let detailsHandled = false;
+          for (const reply of replies) {
+            offset = reply.updateId + 1;
+            if (!matchReply(reply, result.messageId ?? 0, correlationId)) {
+              continue;
+            }
+            const classified = classifyAnswer(reply.text);
+            if (classified.recognized && classified.verb === "DETAILS") {
+              if (reply.callbackQueryId) {
+                try {
+                  await answerCallbackQuery(telegram, reply.callbackQueryId, "Sending details…");
+                } catch {
+                  /* non-fatal */
+                }
+              }
+              if (hasDetails) {
+                const detailsText = buildDetailsMessage({
+                  projectName,
+                  correlationId,
+                  options: optionsList,
+                  details: detailsMap,
+                });
+                try {
+                  await sendMessage(telegram, detailsText, null);
+                } catch {
+                  /* non-fatal */
+                }
+              }
+              detailsHandled = true;
+              continue;
+            }
+            if (reply.callbackQueryId) {
+              try {
+                await answerCallbackQuery(
+                  telegram,
+                  reply.callbackQueryId,
+                  classified.recognized ? `Received: ${classified.verb}` : undefined,
+                );
+              } catch {
+                /* non-fatal */
+              }
+              if (result.messageId) {
+                try {
+                  await editMessageRemoveKeyboard(telegram, result.messageId);
+                } catch {
+                  /* non-fatal */
+                }
+              }
+            }
+            process.stdout.write(
+              JSON.stringify(
+                {
+                  correlationId,
+                  messageId: result.messageId,
+                  sessionId,
+                  status: classified.recognized ? "answered" : "unrecognized",
+                  verb: classified.verb,
+                  raw: classified.raw,
+                  source: reply.callbackQueryId ? "button" : "text",
+                  usageLine,
+                  nextOffset: offset,
+                },
+                null,
+                2,
+              ) + "\n",
+            );
+            return;
+          }
+          await new Promise((resolve) => setTimeout(resolve, detailsHandled ? 1000 : 2000));
+        }
+
+        process.stdout.write(
+          JSON.stringify(
+            { correlationId, messageId: result.messageId, sessionId, status: "pending", usageLine, waitedSeconds: waitSeconds },
+            null,
+            2,
+          ) + "\n",
+        );
+      },
+    }),
+
+    stop: defineCommand({
+      meta: {
+        name: "stop",
+        description: "Mark the active session stopped. Agent MUST exit its loop after this call.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        reason: { type: "string", description: "Reason", default: "user-requested" },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const { sessionId } = enforceActive(projectRoot, true);
+        markStopped(projectRoot, sessionId, String(context.args.reason));
+        process.stdout.write(`session ${sessionId} stopped (${context.args.reason})\n`);
+      },
+    }),
+
+    increment: defineCommand({
+      meta: {
+        name: "increment",
+        description: "Increment a session counter (commits|escalations|deferred). Used by the agent after each action.",
+      },
+      args: {
+        path: { type: "string", alias: "p", description: "Project root", default: "." },
+        field: { type: "positional", required: true, description: "commits | escalations | deferred" },
+      },
+      async run(context) {
+        const projectRoot = toPath(context.args.path);
+        const { sessionId } = enforceActive(projectRoot);
+        const field = String(context.args.field);
+        if (field !== "commits" && field !== "escalations" && field !== "deferred") {
+          process.stderr.write(`grace afk increment: field must be commits|escalations|deferred, got ${field}\n`);
+          process.exit(EXIT_BAD_ARGS);
+        }
+        incrementCounter(projectRoot, sessionId, field);
+        process.stdout.write(`incremented ${field}\n`);
+      },
+    }),
+  },
+});
+
+// START_CONTRACT: buildDoneContext
+//   PURPOSE: Compose the one-sentence `--context` string for `grace afk done` that reports elapsed
+//     session time, counters from state.json, and a compact usage snapshot from the statusline cache.
+//   INPUTS: { sessionStartIso: string, now: Date, commits, escalations, deferred, usageLine?: string }
+//   OUTPUTS: string
+//   SIDE_EFFECTS: none
+// END_CONTRACT: buildDoneContext
+export function buildDoneContext(args: {
+  sessionStartIso: string;
+  now: Date;
+  commits: number;
+  escalations: number;
+  deferred: number;
+  usageLine?: string | null;
+}): string {
+  const start = Date.parse(args.sessionStartIso);
+  const elapsedMs = Number.isFinite(start) ? Math.max(0, args.now.getTime() - start) : 0;
+  const totalMinutes = Math.floor(elapsedMs / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const elapsed = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+
+  const counters = `${args.commits} commits · ${args.escalations} escalations · ${args.deferred} deferred`;
+  const pieces = [`Session: ${elapsed}, ${counters}`];
+  if (args.usageLine) {
+    pieces.push(args.usageLine);
+  }
+  return pieces.join(". ");
+}
+
+// START_CONTRACT: projectNameFromPath
+//   PURPOSE: Convert the project-root basename into a human-readable project name.
+//     grace-marketplace-2 -> "Grace Marketplace 2"
+//   INPUTS: { projectRoot: string }
+//   OUTPUTS: string (Title Case, single spaces)
+//   SIDE_EFFECTS: none
+// END_CONTRACT: projectNameFromPath
+export function projectNameFromPath(projectRoot: string): string {
+  const base = path.basename(path.resolve(projectRoot));
+  if (!base) {
+    return "project";
+  }
+  return base
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function buildAskMessage(input: {
+  correlationId: string;
+  sessionId: string;
+  projectName: string;
+  title: string;
+  context: string;
+  options: string[];
+  myPick: string;
+  confidence: string;
+}): string {
+  // Plain text, no markdown. We intentionally strip any control characters from user-controlled
+  // fields (title/context/options) because the transport sends plain text and we do not want
+  // null bytes or CR/LF from malformed plan entries to garble the message.
+  const clean = (value: string) => value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+
+  const optionsBlock =
+    input.options.length === 0
+      ? "  (no options enumerated)"
+      : input.options.map((option) => `  ${clean(option)}`).join("\n");
+  const pick = input.myPick ? `\nMy pick: ${clean(input.myPick)} (${clean(input.confidence)}% confidence)` : "";
+  return [
+    `[${clean(input.projectName)}] /afk decision ${input.correlationId}`,
+    `(session ${input.sessionId})`,
+    "",
+    clean(input.title),
+    `Situation: ${clean(input.context)}`,
+    "Options:",
+    optionsBlock,
+    pick,
+    "",
+    `Tap a button below, or reply with one of: A / B / C / D / E / PROCEED / STOP / DEFER.`,
+    `If replying by text, prefix with "${input.correlationId}" so I can match your answer.`,
+  ].join("\n");
+}
+
+export type OptionDetail = {
+  id: string;
+  pros: string;
+  cons: string;
+  opportunities: string;
+  risks: string;
+};
+
+// START_CONTRACT: parseDetailsArg
+//   PURPOSE: Parse the --details CLI string into a Map of OptionDetail keyed by option id.
+//     Syntax: "A|pros|cons|opps|risks;B|...;C|..." — 5 pipe-separated fields per option,
+//     entries split by ';' (safer than '|' on Windows cmd shells).
+//   INPUTS: { raw: string }
+//   OUTPUTS: Map<string, OptionDetail>
+//   SIDE_EFFECTS: none
+// END_CONTRACT: parseDetailsArg
+export function parseDetailsArg(raw: string): Map<string, OptionDetail> {
+  const result = new Map<string, OptionDetail>();
+  if (!raw) {
+    return result;
+  }
+  for (const chunk of raw.split(";")) {
+    const parts = chunk.split("|").map((part) => part.trim());
+    if (parts.length < 2 || !parts[0]) {
+      continue;
+    }
+    const [id, pros = "", cons = "", opportunities = "", risks = ""] = parts;
+    result.set(id.toUpperCase(), { id: id.toUpperCase(), pros, cons, opportunities, risks });
+  }
+  return result;
+}
+
+// START_CONTRACT: buildDetailsMessage
+//   PURPOSE: Render a SWOT-style breakdown (Pros / Cons / Opportunities / Risks)
+//     as a plain-text Telegram message, sized for mobile reading.
+//   INPUTS: { projectName, correlationId, options: string[], details: Map<id, OptionDetail> }
+//   OUTPUTS: string — plain text message, <= ~20 lines for 3-option case
+//   SIDE_EFFECTS: none
+// END_CONTRACT: buildDetailsMessage
+// Strip the structural "A:" / "B:" prefix from an option label. The letter is already the row header,
+// so "A:sequential" renders as just "sequential" to avoid the duplicate "A — A:sequential" artefact.
+function stripOptionLetterPrefix(option: string): string {
+  const match = /^\s*[A-Ea-e]\s*:\s*(.+)$/.exec(option);
+  return match ? match[1]!.trim() : option.trim();
+}
+
+export function buildDetailsMessage(args: {
+  projectName: string;
+  correlationId: string;
+  options: string[];
+  details: Map<string, OptionDetail>;
+}): string {
+  const clean = (value: string) => value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+  const letters = ["A", "B", "C", "D", "E"];
+  const lines: string[] = [];
+  lines.push(`[${clean(args.projectName)}] Decision details ${args.correlationId}`);
+  lines.push("");
+  args.options.slice(0, 5).forEach((option, index) => {
+    const letter = letters[index]!;
+    const detail = args.details.get(letter);
+    const label = clean(stripOptionLetterPrefix(option));
+    lines.push(`${letter} — ${label}`);
+    if (!detail) {
+      lines.push(`  (no details provided for ${letter})`);
+      lines.push("");
+      return;
+    }
+    lines.push(`  Pros:          ${clean(detail.pros) || "—"}`);
+    lines.push(`  Cons:          ${clean(detail.cons) || "—"}`);
+    lines.push(`  Opportunities: ${clean(detail.opportunities) || "—"}`);
+    lines.push(`  Risks:         ${clean(detail.risks) || "—"}`);
+    lines.push("");
+  });
+  lines.push("Go back to the previous message and tap A / B / C / PROCEED / DEFER / STOP.");
+  return lines.join("\n");
+}
+
+// START_CONTRACT: buildAskKeyboard
+//   PURPOSE: Construct the inline keyboard for a `grace afk ask` message. One row of A..E letters
+//     (as many as the spec's options), one row of meta verbs. If hasDetails, a [Details] button
+//     is appended as a third row. Callback data = "<corrId>:<verb>".
+//   INPUTS: { correlationId, options, hasDetails }
+//   OUTPUTS: InlineKeyboard
+//   SIDE_EFFECTS: none
+// END_CONTRACT: buildAskKeyboard
+export function buildAskKeyboard(
+  correlationId: string,
+  options: string[],
+  hasDetails = false,
+): InlineKeyboard {
+  const letters = ["A", "B", "C", "D", "E"];
+  const letterRow = options.slice(0, 5).map((_, index) => ({
+    text: letters[index]!,
+    callbackData: `${correlationId}:${letters[index]!}`,
+  }));
+
+  const rows: InlineKeyboard = [];
+  if (letterRow.length > 0) {
+    rows.push(letterRow);
+  }
+  rows.push([
+    { text: "PROCEED", callbackData: `${correlationId}:PROCEED` },
+    { text: "DEFER", callbackData: `${correlationId}:DEFER` },
+    { text: "STOP", callbackData: `${correlationId}:STOP` },
+  ]);
+  if (hasDetails) {
+    rows.push([{ text: "📖 Details", callbackData: `${correlationId}:DETAILS` }]);
+  }
+  return rows;
+}
+
+// START_CHANGE_SUMMARY
+//   LAST_CHANGE: [3.7.0-grace-afk] Initial module. Post-review fixes:
+//                - plain-text buildAskMessage (control-char stripping, no markdown)
+//                - EXIT_TELEGRAM_FAILURE / EXIT_CONFIG_MISSING / EXIT_BAD_ARGS replace exit(1)
+//                - --class validated against DECISION_CLASSES (no more silent garbage)
+//                - --context canonical, --contextLine alias kept for back-compat
+//                - dead tautology in report cmd removed
+// END_CHANGE_SUMMARY

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -2,6 +2,7 @@
 
 import { defineCommand, type CommandDef, runMain } from "citty";
 
+import { afkCommand } from "./grace-afk";
 import { fileCommand } from "./grace-file";
 import { lintCommand } from "./grace-lint";
 import { moduleCommand } from "./grace-module";
@@ -15,6 +16,7 @@ const main = defineCommand({
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {
+    afk: afkCommand,
     file: fileCommand,
     lint: lintCommand,
     module: moduleCommand,


### PR DESCRIPTION
## Summary

Adds the autonomous AFK mode from my fork — the feature you mentioned liking. The agent keeps working through the active GRACE 4 change plan while the user is away, with a hard CLI-enforced time budget and Telegram escalation for one-way-door decisions.

## What's inside

- **`grace afk` CLI** (`src/grace-afk.ts`, `src/afk/`): `start / tick / ask / check / journal / defer / increment / report / stop`. The CLI, not the LLM, owns the budget clock — `tick` exits `42/43/44` and the agent must stop.
- **`grace-afk` skill** — the /afk harness: startup protocol, work loop, autonomy matrix (act / defer / escalate / rollback), idle-fill review while waiting for replies, end-of-session dashboard.
- **`grace-ask-human` skill** — escalation discipline: ≤10-line Telegram message, inline A-E/PROCEED/DEFER/STOP keyboard, optional per-option SWOT details button, exponential polling backoff.
- Telegram config lookup: `$GRACE_AFK_CONFIG` → `<project>/.grace-afk.json` → `~/.grace/afk.json` (template ships in `grace-init` assets).
- 5 test files (74 tests), loop diagram, README rows, marketplace registration.

## Notes

- No dependencies on other fork features — self-contained on top of 4.0.4.
- Session artifacts land in `docs/afk-sessions/<id>/` (state.json, decisions.md, deferred.md).
- `src/afk/usage.ts` optionally reads the Claude Code statusline usage cache for budget%; degrades to null when absent.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test` — 387 pass / 2 fail; both failures are pre-existing on `main` in my Windows environment (`project-utils` adapter-failed, `packed-cli-smoke` EACCES) and unrelated to this change
- All 74 afk-specific tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
