### PR TITLE
fix(lint): credit log markers emitted by non-JS loggers (e.g. Go or Java)

### DIFF
--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -112,6 +112,109 @@ export const value = true;
     expect(hasRuntimeMarkerEvidence(`// const marker$ = "${marker}";\nconsole.info(marker$ + " ok");`, marker)).toBe(false);
   });
 
+  it("credits capitalised logger methods used by Go, Java, and C#", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    // Go stdlib log
+    expect(hasRuntimeMarkerEvidence(`log.Info("${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`log.Warn("${marker} ok")`, marker)).toBe(true);
+    // Go slog, context-taking variants
+    expect(hasRuntimeMarkerEvidence(`d.log.InfoContext(ctx, "${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`slog.Error("${marker} failed")`, marker)).toBe(true);
+    // Go logrus/zap, printf form
+    expect(hasRuntimeMarkerEvidence(`logger.Errorf("${marker} failed: %v", err)`, marker)).toBe(true);
+    // java.util.logging - note `severe` is its error level, not a Go/SLF4J name
+    expect(hasRuntimeMarkerEvidence(`LOG.info("${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`LOG.severe("${marker} failed")`, marker)).toBe(true);
+    // Java SLF4J / Log4j, on a receiver not called `logger`
+    expect(hasRuntimeMarkerEvidence(`LOG.debug("${marker} ok")`, marker)).toBe(true);
+    // C# ILogger. The receiver here is NOT `logger`, so this passes only because
+    // the `Log*` method names are matched - not by the bare `logger.` prefix.
+    expect(hasRuntimeMarkerEvidence(`_log.LogInformation("${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`_log.LogWarning("${marker} ok")`, marker)).toBe(true);
+  });
+
+  it("credits the level spellings and suffixes the alternation exists for", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    // java.util.logging: `warn` cannot cover this - the required `(` makes the
+    // engine backtrack on "ing(", and `LOG.` is not the bare `logger.` prefix.
+    expect(hasRuntimeMarkerEvidence(`LOG.warning("${marker} ok")`, marker)).toBe(true);
+    // C# ILogger, same spelling capitalised
+    expect(hasRuntimeMarkerEvidence(`LOG.Warning("${marker} ok")`, marker)).toBe(true);
+    // Go zap, sugared key/value form
+    expect(hasRuntimeMarkerEvidence(`zap.Infow("${marker} ok", "k", v)`, marker)).toBe(true);
+    // Go glog, println form
+    expect(hasRuntimeMarkerEvidence(`glog.Infoln("${marker} ok")`, marker)).toBe(true);
+  });
+
+  it("credits the declaration forms the targeted languages actually use", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    const emit = `\nlog.Info(prefix + "[run][BLOCK_RUN] ok")`;
+    // Go short declaration - its primary form, matched only by the `:?=` clause
+    expect(hasRuntimeMarkerEvidence(`prefix := "[Example]"${emit}`, marker)).toBe(true);
+    // Go const, the idiomatic form for a log prefix
+    expect(hasRuntimeMarkerEvidence(`const prefix = "[Example]"${emit}`, marker)).toBe(true);
+    // Go untyped var
+    expect(hasRuntimeMarkerEvidence(`var prefix = "[Example]"${emit}`, marker)).toBe(true);
+    // TypeScript with a type annotation, which `:?=` was written for
+    expect(hasRuntimeMarkerEvidence(`const prefix: string = "[Example]";${emit}`, marker)).toBe(true);
+    // Go `:=` holding the WHOLE marker. Credited only by the empty-remainder
+    // branch of the concatenation path: the identifier path's assignment pattern
+    // ends in a bare `=` and rejects `:=`. Restricting concatenation to proper
+    // prefixes, on the view that whole markers "belong" to the identifier check,
+    // would silently drop Go's primary full-marker form.
+    expect(hasRuntimeMarkerEvidence(`marker := "${marker}"\nlog.Info(marker)`, marker)).toBe(true);
+
+    // Go TYPED var - still unsupported, but it must now bind NOTHING rather than
+    // bind the type token `string`. The second case is the one that mattered: a
+    // line using that token for anything else would otherwise credit the marker.
+    expect(hasRuntimeMarkerEvidence(`var prefix string = "[Example]"${emit}`, marker)).toBe(false);
+    expect(
+      hasRuntimeMarkerEvidence(`var modulePrefix string = "[Example]"\nlog.Info("[run][BLOCK_RUN] " + string(body))`, marker),
+    ).toBe(false);
+  });
+
+  it("requires the remainder to adjoin the constant, not merely share its line", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    const decl = `const logModule = "[Example]"\n`;
+    // Genuine assembly, in the forms real code uses.
+    expect(hasRuntimeMarkerEvidence(`${decl}log.Info(logModule+"[run][BLOCK_RUN] ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`${decl}log.Info(logModule + "[run][BLOCK_RUN] ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`${decl}logger.info(\`\${logModule}[run][BLOCK_RUN] ok\`)`, marker)).toBe(true);
+
+    // Both halves present, never concatenated: the marker is not emitted here.
+    expect(
+      hasRuntimeMarkerEvidence(`${decl}logger.Warn("unrelated " + logModule + " text [run][BLOCK_RUN] not the marker")`, marker),
+    ).toBe(false);
+    expect(hasRuntimeMarkerEvidence(`${decl}log.Info(logModule + "[deploy] then [run][BLOCK_RUN] later")`, marker)).toBe(false);
+  });
+
+  it("does not read obj.name as a use of a constant called name", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    // The marker is bound to `logger` but never emitted; `obj.logger.Info(...)`
+    // is an unrelated call. Without `.` in the identifier lookbehind this is
+    // credited, and a module passes its required-marker check without emitting.
+    expect(hasRuntimeMarkerEvidence(`const logger = "${marker}";\nobj.logger.Info("unrelated")`, marker)).toBe(false);
+    expect(hasRuntimeMarkerEvidence(`const log = "${marker}";\nobj.log.Warning("unrelated")`, marker)).toBe(false);
+  });
+
+  it("credits a marker assembled from a module-prefix constant", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    const emitted = [`const logModule = "[Example]"`, `log.Info(logModule+"[run][BLOCK_RUN] ok")`].join("\n");
+    expect(hasRuntimeMarkerEvidence(emitted, marker)).toBe(true);
+
+    // A different block in the same family must not be credited.
+    const other = [`const logModule = "[Example]"`, `log.Info(logModule+"[run][BLOCK_OTHER] ok")`].join("\n");
+    expect(hasRuntimeMarkerEvidence(other, marker)).toBe(false);
+
+    // An unknown prefix identifier resolves to nothing.
+    const unknown = [`const logModule = "[Example]"`, `log.Info(otherModule+"[run][BLOCK_RUN] ok")`].join("\n");
+    expect(hasRuntimeMarkerEvidence(unknown, marker)).toBe(false);
+
+    // A property access must not resolve a constant of the same name.
+    const shadowed = [`const log = "[Example]"`, `d.log.Info("unrelated")`].join("\n");
+    expect(hasRuntimeMarkerEvidence(shadowed, marker)).toBe(false);
+  });
+
   it("emits bounded-confidence diagnostics for heuristic Python analysis", () => {
     const hasPython = ["python3", "python"].some((binary) => {
       const result = spawnSync(binary, ["--version"], { stdio: "ignore" });

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -131,8 +131,19 @@ function isCommentOnlyLine(line: string) {
   return /^\s*(\/\/|#|--|;+|\*)/.test(line);
 }
 
+/**
+ * Case-insensitive, with the printf/context suffixes those ecosystems use,
+ * because Go, Java, and C# capitalise logger methods: `.Info(`, `.InfoContext(`,
+ * `.Errorf(`. A lowercase-only pattern recognises no emission there at all.
+ *
+ * `severe` is java.util.logging's error level, and the `log*` names are C#
+ * ILogger's (`LogWarning`, `LogInformation`). Without them those two only match
+ * when the receiver happens to be called `logger`, which is not a guarantee.
+ */
 function looksLikeEvidenceEmission(line: string) {
-  return /(console\.|logger\.|tracer\.|trace\s*\(|emit\s*\(|\.(info|warn|error|debug|trace)\s*\()/.test(line);
+  return /(console\.|logger\.|tracer\.|trace\s*\(|emit\s*\(|\.(?:info|warn(?:ing)?|error|debug|trace|severe|log(?:information|warning|error|debug|trace|critical))(?:f|w|ln)?(?:context)?\s*\()/i.test(
+    line,
+  );
 }
 
 /** Extracts the semantic block name encoded at the end of a required log marker. */
@@ -142,9 +153,10 @@ export function parseMarkerBlockName(marker: string) {
 }
 
 /**
- * Returns true when a required marker is emitted directly or through a same-file
- * identifier assigned to that exact marker. Identifier-aware boundaries keep
- * names such as marker$ distinct from marker$Other.
+ * Returns true when a required marker is emitted directly, through a same-file
+ * identifier assigned to that exact marker, or assembled from an identifier
+ * holding a PREFIX of it concatenated with the remainder. Identifier-aware
+ * boundaries keep names such as marker$ distinct from marker$Other.
  */
 export function hasRuntimeMarkerEvidence(text: string, marker: string) {
   const lines = text.split("\n");
@@ -168,10 +180,82 @@ export function hasRuntimeMarkerEvidence(text: string, marker: string) {
     }
   }
 
-  return [...identifiers].some((identifier) => {
-    const identifierUse = new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(identifier)}(?![A-Za-z0-9_$])`);
-    return lines.some((line) => !isCommentOnlyLine(line) && looksLikeEvidenceEmission(line) && identifierUse.test(line));
-  });
+  if (
+    [...identifiers].some((identifier) => {
+      // `.` is in the lookbehind so `obj.logger` is not read as a use of a
+      // constant named `logger`. Broadening the emission match to capitalised
+      // methods makes that reachable: `const logger = "<marker>"` plus an
+      // unrelated `obj.logger.Info(...)` would otherwise credit the marker.
+      const identifierUse = new RegExp(`(?<![A-Za-z0-9_$.])${escapeRegExp(identifier)}(?![A-Za-z0-9_$])`);
+      return lines.some((line) => !isCommentOnlyLine(line) && looksLikeEvidenceEmission(line) && identifierUse.test(line));
+    })
+  ) {
+    return true;
+  }
+
+  return hasConcatenatedMarkerEvidence(lines, marker);
+}
+
+/**
+ * Credits `logModule+"[fn][BLOCK_X]"`, where the whole marker is neither on the
+ * line nor bound to an identifier. Each binding gives one way the marker could
+ * split: its value must prefix the marker, the remainder must be on the line.
+ */
+function hasConcatenatedMarkerEvidence(lines: string[], marker: string) {
+  const constants = new Map<string, Set<string>>();
+  // The name must open the line, follow a declaration keyword, or follow `( , ;`.
+  // Allowing any whitespace before it let Go's `var prefix string = "..."` bind
+  // the TYPE token: `:?=` fails at `string`, the engine re-scans, and `string`
+  // becomes the name. A line using that token for anything else - `string(body)` -
+  // then credits a marker nothing emitted.
+  const binding =
+    /(?:^\s*|[(,;]\s*|\b(?:const|let|var|final|static)\s+)([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::[^=\n]+?)?:?=\s*(["'`])((?:\\.|(?!\2)[^\\])*)\2/g;
+
+  for (const line of lines) {
+    if (isCommentOnlyLine(line)) {
+      continue;
+    }
+    for (const match of line.matchAll(binding)) {
+      const name = match[1]!;
+      if (!constants.has(name)) {
+        constants.set(name, new Set());
+      }
+      constants.get(name)!.add(match[3]!);
+    }
+  }
+
+  // The lookbehind on `.` keeps `d.log` from counting as a use of `log`.
+  const boundary = (name: string) => `(?<![A-Za-z0-9_$.])${escapeRegExp(name)}(?![A-Za-z0-9_$])`;
+
+  const splits: RegExp[] = [];
+  for (const [name, values] of constants) {
+    for (const value of values) {
+      if (!marker.startsWith(value)) {
+        continue;
+      }
+      const remainder = marker.slice(value.length);
+      if (remainder === "") {
+        // The binding already holds the whole marker; using it is the emission.
+        splits.push(new RegExp(boundary(name)));
+        continue;
+      }
+      // The remainder must ADJOIN the identifier, not merely share the line with
+      // it. Checking both appear anywhere credits `log("… " + p + " … <tail>")`,
+      // where nothing ever assembles the marker - a false pass on a gate whose
+      // whole job is to prove the marker is emitted.
+      splits.push(
+        new RegExp(`(?:${boundary(name)}\\s*\\+\\s*["'\`]|\\$\\{\\s*${escapeRegExp(name)}\\s*\\})${escapeRegExp(remainder)}`),
+      );
+    }
+  }
+
+  if (splits.length === 0) {
+    return false;
+  }
+
+  return lines.some(
+    (line) => !isCommentOnlyLine(line) && looksLikeEvidenceEmission(line) && splits.some((split) => split.test(line)),
+  );
 }
 
 export function collectCodeFiles(root: string, ignoredDirs: string[], currentDir = root): string[] {


### PR DESCRIPTION
## Problem

The emission pattern does not match loggers with mixed-case method names, and does not match markers built by joining a constant to a literal. Both shapes are normal in Go, Java and C#.

The effect is that `required-log-marker-not-found` fires against code that plainly emits the marker. On a Go project the check cannot pass at all: every logger call is `.Info(`, `.Warn(` or `.InfoContext(`, and the pattern only matched lowercase names.

## What changes

- Match method names case-insensitively. Go, Java and C# export logger methods, so they are capitalised.
- Accept the suffixes those ecosystems use: `.Infof(`, `.Infow(`, `.Infoln(`, `.InfoContext(`.
- Add `severe` (java.util.logging) and the `Log*` names (C# ILogger). Without them, those two match only when the receiver happens to be named `logger`.
- Credit a marker joined from a constant and a literal, such as `logModule+"[fn][BLOCK_X]"` where `logModule` is `"[Module]"`. Declaring the module name once is what the marker convention asks for, but the whole marker is then neither on the line nor bound to one identifier, so no existing check could see it. This extends the constant support added in 7746ff6.
- Require the literal to **adjoin** the constant, through `+ "` or `${...}`. If both merely appear on the line, `log("... " + p + " ... [fn][BLOCK_X]")` would be credited, and that line joins nothing.
- Fix a **pre-existing** false positive that the above makes reachable. The identifier lookbehind had no `.`, so `obj.logger` read as a use of a constant named `logger`. Harmless while only lowercase methods matched; once `.Info(` matches, `const logger = "<marker>"` plus an unrelated `obj.logger.Info(...)` credits a marker nothing emitted.

## Out of scope, deliberately

- A constant declared in a sibling file. Resolving it needs a wider scope passed in, which changes the signature and every call site.
- Excluding terminal `.Fatal(` and `.Panic(` calls. The bare `logger.` prefix matches them whatever the method is, so excluding them changes behaviour that is already there.

Happy to take either on if you would prefer them included.

## Verification

- No signature and no call-site changes. Same-file only, as before.
- Each guard is mutation-tested. Removing `(?:ing)?`, the `f|w|ln` suffixes, `context`, the `/i` flag, the `.` in the lookbehind, or the `:?=` that admits Go's `:=` each fails a test.
- Linux, bun 1.3.14, matching this repo's CI: **311 pass, 1 fail**. The one failure is `grace query core > wires module ... through the CLI`, which fails the same way on an unmodified `main` and takes ~6s, so it looks environment-sensitive rather than related to this change.

## Provenance

This change was written with Claude, then adversarially reviewed by both agents and humans before submission. The review record is public, in a PR on the fork: https://github.com/pilotso11/grace-marketplace/pull/1

That round found three real defects, all fixed here: the pre-existing identifier false positive above, a binding regex that captured a Go type token as a constant name, and the loose co-occurrence check that this PR replaces with an adjacency requirement. Tests pin each one.