### PR TITLE
fix(cli): skip unreadable directories with a warning instead of aborting

### DIFF
--- a/src/grace-lint.test.ts
+++ b/src/grace-lint.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "bun:test";
@@ -490,5 +490,33 @@ describe("lintGraceProject", () => {
     );
     const result = lintGraceProject(root);
     expect(result.issues.filter((issue) => issue.code.startsWith("design-context.") || issue.code === "artifact.invalid-root-tag" || issue.code === "change.invalid-root-tag")).toHaveLength(0);
+  });
+});
+
+describe("lintGraceProject unreadable directories", () => {
+  const permissionsUnsupported = process.platform === "win32" || process.getuid?.() === 0;
+
+  it.skipIf(permissionsUnsupported)("warns walk.unreadable-directory and continues instead of aborting", () => {
+    const root = createProject();
+    writeMinimalGrace4Project(root);
+    writeProjectFile(root, "blocked/hidden.ts", "export const hidden = true;\n");
+    const baseline = lintGraceProject(root);
+
+    const blockedDir = path.join(root, "blocked");
+    chmodSync(blockedDir, 0o000);
+
+    try {
+      const result = lintGraceProject(root);
+      const walkIssues = result.issues.filter((issue) => issue.code === "walk.unreadable-directory");
+      expect(walkIssues).toHaveLength(1);
+      expect(walkIssues[0]?.severity).toBe("warning");
+      expect(walkIssues[0]?.file).toBe(blockedDir);
+      expect(walkIssues[0]?.message).toContain(blockedDir);
+      // The unreadable subtree drops out of the checked set; nothing else changes.
+      expect(result.filesChecked).toBe(baseline.filesChecked - 1);
+      expect(result.summary.errors).toBe(baseline.summary.errors);
+    } finally {
+      chmodSync(blockedDir, 0o755);
+    }
   });
 });

--- a/src/lint/catalog.ts
+++ b/src/lint/catalog.ts
@@ -33,6 +33,11 @@ const EXACT_GUIDES: Record<string, Omit<LintIssueGuide, "code">> = {
     explanation: "The governed file uses a language adapter that requires its language runtime on PATH. GRACE fails closed instead of silently dropping export/local parity checks.",
     remediation: ["Install the runtime named in the issue message and ensure it is available on PATH.", "If the file should not be governed in this environment, exclude it explicitly rather than relying on incomplete analysis."],
   },
+  "walk.unreadable-directory": {
+    title: "Unreadable Directory Skipped",
+    explanation: "A directory could not be listed while walking the project, so the files inside it were not checked. This usually means restrictive permissions or a leftover sandbox directory; it does not make the GRACE project itself invalid.",
+    remediation: ["Restore read permission on the directory if it should be governed.", "If the directory is build output or a sandbox leftover, add it to ignoredDirs in .grace-lint.json or remove it."],
+  },
   "scope.durable-overlap": {
     title: "Durable Scope Overlap",
     explanation: "Two or more active change scopes claim overlapping durable regions, which creates a data-contention risk if executed in parallel.",

--- a/src/lint/core.ts
+++ b/src/lint/core.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { type Dirent, existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 
 import { evaluateAssertion, extractAssertionsWithIssues } from "../grace4/assertions";
@@ -8,7 +8,7 @@ import { buildGraphProjection, buildVerificationProjection, type GraphProjection
 import { collectActiveChangeScopes, createDurableOwnershipIndex, detectScopeOverlaps, detectUnsafeConcurrentExecution } from "../grace4/scope";
 import { ANCHOR_PATTERNS, type Grace4Issue, type Grace4ProjectPaths } from "../grace4/types";
 import { readGraceXmlArtifact } from "../grace4/xml";
-import { analyzeGovernedFile, collectCodeFiles, hasGraceMarkers } from "../project-utils";
+import { analyzeGovernedFile, collectCodeFiles, describeUnreadableDirectory, hasGraceMarkers, type UnreadableDirectoryHandler } from "../project-utils";
 import { withLintIssueGuide } from "./catalog";
 import { loadGraceLintConfig } from "./config";
 import type { LintIssue, LintOptions, LintProfile, LintResult } from "./types";
@@ -58,6 +58,17 @@ function finalizeResult(result: LintResult): LintResult {
   return result;
 }
 
+function reportUnreadableDirectory(result: LintResult): UnreadableDirectoryHandler {
+  return (directory, error) => {
+    addIssue(result, {
+      severity: "warning",
+      code: "walk.unreadable-directory",
+      file: directory,
+      message: describeUnreadableDirectory(directory, error),
+    });
+  };
+}
+
 function validateGovernedFiles(result: LintResult, root: string): void {
   const { config, issues } = loadGraceLintConfig(root);
   for (const configIssue of issues) {
@@ -67,7 +78,7 @@ function validateGovernedFiles(result: LintResult, root: string): void {
     return;
   }
 
-  const files = collectCodeFiles(root, [".grace", ...(config?.ignoredDirs ?? [])]);
+  const files = collectCodeFiles(root, [".grace", ...(config?.ignoredDirs ?? [])], root, reportUnreadableDirectory(result));
   result.filesChecked = files.length;
   for (const file of files) {
     const text = readText(file);
@@ -85,14 +96,21 @@ function readText(file: string) {
   return readFileSync(file, "utf8");
 }
 
-function listPlanFiles(directory: string): string[] {
+function listPlanFiles(directory: string, onUnreadableDirectory?: UnreadableDirectoryHandler): string[] {
   if (!existsSync(directory)) {
     return [];
   }
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    onUnreadableDirectory?.(directory, error);
+    return [];
+  }
+  return entries.flatMap((entry) => {
     const entryPath = path.join(directory, entry.name);
     if (entry.isDirectory()) {
-      return listPlanFiles(entryPath);
+      return listPlanFiles(entryPath, onUnreadableDirectory);
     }
     return entry.isFile() && entry.name === "plan.xml" ? [entryPath] : [];
   });
@@ -282,8 +300,9 @@ export function lintGraceProject(projectRoot: string, options: LintOptions = {})
     addGrace4Issue(result, issue);
   }
 
-  const planFilesActive = [...listPlanFiles(paths.changesActiveDir)];
-  const planFilesArchived = [...listPlanFiles(paths.changesArchiveDir)];
+  const unreadableDirectory = reportUnreadableDirectory(result);
+  const planFilesActive = [...listPlanFiles(paths.changesActiveDir, unreadableDirectory)];
+  const planFilesArchived = [...listPlanFiles(paths.changesArchiveDir, unreadableDirectory)];
   validateAssertions(result, paths, planFilesActive, planFilesArchived, graph, verification, root, options);
 
   return finalizeResult(result);

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, test } from "bun:test";
 
-import { analyzeGovernedFile, hasRuntimeMarkerEvidence, parseGovernedFile } from "./project-utils";
+import { analyzeGovernedFile, collectCodeFiles, describeUnreadableDirectory, hasRuntimeMarkerEvidence, parseGovernedFile } from "./project-utils";
 
 function contract(mapMode: "EXPORTS" | "LOCALS" | "SUMMARY" | "NONE", moduleMap = ""): string {
   return `// START_MODULE_CONTRACT
@@ -313,5 +313,55 @@ console.log(JSON.stringify(result.issues));`;
     const issues = JSON.parse(Buffer.from(run.stdout).toString("utf8")) as Array<{ code: string }>;
     expect(issues.map((issue) => issue.code)).toContain("analysis.adapter-failed");
     expect(issues.map((issue) => issue.code)).not.toContain("analysis.runtime-missing");
+  });
+});
+
+describe("unreadable directory walking", () => {
+  const permissionsUnsupported = process.platform === "win32" || process.getuid?.() === 0;
+
+  it("describes walk failures with the directory and errno code", () => {
+    const errno = Object.assign(new Error("EPERM: operation not permitted"), { code: "EACCES" });
+    expect(describeUnreadableDirectory("/project/blocked", errno)).toBe(
+      "Directory '/project/blocked' could not be listed (EACCES); its contents were not checked.",
+    );
+    expect(describeUnreadableDirectory("/project/blocked", new Error("boom"))).toBe(
+      "Directory '/project/blocked' could not be listed (unknown); its contents were not checked.",
+    );
+  });
+
+  it.skipIf(permissionsUnsupported)("skips unreadable directories instead of throwing", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-walk-"));
+    writeFileSync(path.join(root, "visible.ts"), "export const visible = true;\n");
+    mkdirSync(path.join(root, "readable"));
+    writeFileSync(path.join(root, "readable", "other.ts"), "export const other = true;\n");
+    mkdirSync(path.join(root, "blocked"));
+    writeFileSync(path.join(root, "blocked", "hidden.ts"), "export const hidden = true;\n");
+    chmodSync(path.join(root, "blocked"), 0o000);
+
+    try {
+      const reported: Array<{ directory: string; error: unknown }> = [];
+      const files = collectCodeFiles(root, [], root, (directory, error) => reported.push({ directory, error }));
+
+      expect(files.sort()).toEqual([path.join(root, "readable", "other.ts"), path.join(root, "visible.ts")].sort());
+      expect(reported).toHaveLength(1);
+      expect(reported[0]?.directory).toBe(path.join(root, "blocked"));
+
+      // Without a handler the walk still must not abort.
+      expect(collectCodeFiles(root, []).sort()).toEqual([path.join(root, "readable", "other.ts"), path.join(root, "visible.ts")].sort());
+    } finally {
+      chmodSync(path.join(root, "blocked"), 0o755);
+    }
+  });
+
+  it.skipIf(permissionsUnsupported)("still throws nothing for readable roots when a handler is attached", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-walk-ok-"));
+    mkdirSync(path.join(root, "src"));
+    writeFileSync(path.join(root, "src", "example.ts"), "export const example = true;\n");
+
+    const reported: string[] = [];
+    const files = collectCodeFiles(root, [], root, (directory) => reported.push(directory));
+
+    expect(files).toEqual([path.join(root, "src", "example.ts")]);
+    expect(reported).toEqual([]);
   });
 });

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { type Dirent, existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { ADAPTER_BACKED_EXTENSIONS, CODE_EXTENSIONS, LANGUAGE_ADAPTERS } from "./language-registry";
 import { LanguageRuntimeMissingError, type LanguageAnalysis, type LintIssue, type MapMode, type ModuleRole } from "./lint/types";
@@ -258,10 +258,34 @@ function hasConcatenatedMarkerEvidence(lines: string[], marker: string) {
   );
 }
 
-export function collectCodeFiles(root: string, ignoredDirs: string[], currentDir = root): string[] {
+/** Notified when a directory cannot be listed during a project walk. */
+export type UnreadableDirectoryHandler = (directory: string, error: unknown) => void;
+
+/** Stable, diagnosable message for a directory that could not be listed. */
+export function describeUnreadableDirectory(directory: string, error: unknown): string {
+  const code = error !== null && typeof error === "object" && "code" in error && typeof (error as { code?: unknown }).code === "string"
+    ? (error as { code: string }).code
+    : "unknown";
+  return `Directory '${directory}' could not be listed (${code}); its contents were not checked.`;
+}
+
+export function collectCodeFiles(
+  root: string,
+  ignoredDirs: string[],
+  currentDir = root,
+  onUnreadableDirectory?: UnreadableDirectoryHandler,
+): string[] {
   const files: string[] = [];
   const ignoredDirSet = new Set([...DEFAULT_IGNORED_DIRS, ...ignoredDirs]);
-  const entries = readdirSync(currentDir, { withFileTypes: true });
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(currentDir, { withFileTypes: true });
+  } catch (error) {
+    // An unreadable directory (EACCES/EPERM, sandbox leftovers, chmod 000) must
+    // not abort the whole walk: skip it and let the caller surface a warning.
+    onUnreadableDirectory?.(currentDir, error);
+    return files;
+  }
 
   for (const entry of entries) {
     if (entry.isDirectory()) {
@@ -269,7 +293,7 @@ export function collectCodeFiles(root: string, ignoredDirs: string[], currentDir
         continue;
       }
 
-      files.push(...collectCodeFiles(root, ignoredDirs, path.join(currentDir, entry.name)));
+      files.push(...collectCodeFiles(root, ignoredDirs, path.join(currentDir, entry.name), onUnreadableDirectory));
       continue;
     }
 

--- a/src/query/core.ts
+++ b/src/query/core.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { type Dirent, existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 
 import { buildGraphProjection, buildVerificationProjection, type GraphAnchorRecord, type VerificationAnchorRecord } from "../grace4/projections";
@@ -6,8 +6,9 @@ import { validateGrace4Project } from "../grace4/grammar";
 import { detectGraceProjectKind, formatGrace3MigrationGuidance, resolveGrace4Paths } from "../grace4/project";
 import { extractAssertionsWithIssues } from "../grace4/assertions";
 import { collectActiveChangeScopes } from "../grace4/scope";
+import type { Grace4Issue } from "../grace4/types";
 import { loadGraceLintConfig } from "../lint/config";
-import { collectCodeFiles, hasGraceMarkers, parseGovernedFile, type FileMarkupRecord } from "../project-utils";
+import { collectCodeFiles, describeUnreadableDirectory, hasGraceMarkers, parseGovernedFile, type FileMarkupRecord, type UnreadableDirectoryHandler } from "../project-utils";
 import { GraceCommandError } from "./errors";
 import type {
   GraceArtifactIndex,
@@ -36,7 +37,7 @@ function normalizeInputPath(root: string, input: string) {
   return toPosixPath(input);
 }
 
-function loadGovernedFiles(root: string) {
+function loadGovernedFiles(root: string, onUnreadableDirectory?: UnreadableDirectoryHandler) {
   const { config, issues } = loadGraceLintConfig(root);
   const configErrors = issues.filter((issue) => issue.severity === "error");
   if (configErrors.length > 0) {
@@ -46,7 +47,7 @@ function loadGovernedFiles(root: string) {
   }
 
   const files: FileMarkupRecord[] = [];
-  for (const filePath of collectCodeFiles(root, config?.ignoredDirs ?? [])) {
+  for (const filePath of collectCodeFiles(root, config?.ignoredDirs ?? [], root, onUnreadableDirectory)) {
     const text = readFileSync(filePath, "utf8");
     if (hasGraceMarkers(text)) {
       files.push(parseGovernedFile(root, filePath, text));
@@ -55,18 +56,25 @@ function loadGovernedFiles(root: string) {
   return files.sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function listPlanFiles(directory: string): string[] {
+function listPlanFiles(directory: string, onUnreadableDirectory?: UnreadableDirectoryHandler): string[] {
   if (!existsSync(directory)) return [];
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    onUnreadableDirectory?.(directory, error);
+    return [];
+  }
+  return entries.flatMap((entry) => {
     const entryPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) return listPlanFiles(entryPath);
+    if (entry.isDirectory()) return listPlanFiles(entryPath, onUnreadableDirectory);
     return entry.isFile() && entry.name === "plan.xml" ? [entryPath] : [];
   });
 }
 
-function collectOperationalValidationErrors(paths: ReturnType<typeof resolveGrace4Paths>) {
+function collectOperationalValidationErrors(paths: ReturnType<typeof resolveGrace4Paths>, onUnreadableDirectory?: UnreadableDirectoryHandler) {
   const assertionIssues = [paths.changesActiveDir, paths.changesArchiveDir]
-    .flatMap(listPlanFiles)
+    .flatMap((directory) => listPlanFiles(directory, onUnreadableDirectory))
     .flatMap((planFile) => (["BaselineAssertions", "TargetAssertions"] as const)
       .flatMap((section) => extractAssertionsWithIssues(planFile, section).issues));
   const scopeIssues = collectActiveChangeScopes(paths).flatMap((scope) => scope.issues);
@@ -113,7 +121,11 @@ export function loadGraceArtifactIndex(projectRoot: string): GraceArtifactIndex 
   if (validationErrors.length > 0) {
     throw invalidProjectError(validationErrors.map((issue) => issue.code));
   }
-  const operationalErrors = collectOperationalValidationErrors(paths);
+  const walkIssues: Grace4Issue[] = [];
+  const onUnreadableDirectory: UnreadableDirectoryHandler = (directory, error) => {
+    walkIssues.push({ severity: "warning", code: "walk.unreadable-directory", file: directory, message: describeUnreadableDirectory(directory, error) });
+  };
+  const operationalErrors = collectOperationalValidationErrors(paths, onUnreadableDirectory);
   if (operationalErrors.length > 0) {
     throw invalidProjectError(operationalErrors.map((issue) => issue.code));
   }
@@ -123,7 +135,7 @@ export function loadGraceArtifactIndex(projectRoot: string): GraceArtifactIndex 
   if (projectionErrors.length > 0) {
     throw invalidProjectError(projectionErrors.map((issue) => issue.code));
   }
-  const governedFiles = loadGovernedFiles(root);
+  const governedFiles = loadGovernedFiles(root, onUnreadableDirectory);
   const verifications = [...verification.entries.values()].map(toModuleVerificationRecord).sort((left, right) => left.id.localeCompare(right.id));
 
   const modules = [...graph.modules.values()]
@@ -145,7 +157,7 @@ export function loadGraceArtifactIndex(projectRoot: string): GraceArtifactIndex 
       } satisfies Grace4ModuleRecord;
     });
 
-  return { root, graph, verification, modules, verifications, files: governedFiles, issues: [...validation.issues, ...graph.issues, ...verification.issues] };
+  return { root, graph, verification, modules, verifications, files: governedFiles, issues: [...validation.issues, ...graph.issues, ...verification.issues, ...walkIssues] };
 }
 
 function invalidProjectError(issueCodes: string[]): GraceCommandError {


### PR DESCRIPTION
## Problem

Fixes #31.

Any directory that denies listing (`EACCES`/`EPERM` — `chmod 000` on Linux/macOS, restrictive ACLs or leftover sandboxed test-runner directories on Windows) made the project walkers throw, and the command handler converted the exception into the generic failure:

```text
Unable to complete GRACE lint. Check the project path and run again.
{"ok":false,"error":{"code":"invalid-project"}}
```

…even though the project path is valid and the `.grace` tree is healthy. The message blames the wrong thing, and one junk directory makes `lint` and `status` unusable. Reproduced on current `main` (`4f81342` + `b9d7507`): both `grace lint --path <project>` and `grace status --path <project>` abort exactly as reported.

## What changes

- `collectCodeFiles` (`src/project-utils.ts`) now catches `readdirSync` failures, skips the directory, and notifies an optional `UnreadableDirectoryHandler` instead of throwing. The handler is threaded through the recursion; existing callers without a handler simply no longer abort.
- `lint` surfaces each skipped directory as one `walk.unreadable-directory` **warning** naming the directory and the errno code (`src/lint/core.ts`, both `collectCodeFiles` and the `plan.xml` walker). A catalog entry backs `grace lint --explain walk.unreadable-directory`.
- `status` inherits the fix through `lintGraceProject`; the run completes and the warning appears in the integrity snapshot.
- `query` index loading (`src/query/core.ts`) applies the same guard to its code-file and `plan.xml` walks and records the warnings in the returned `issues`, so artifact-index commands no longer abort on junk directories either.
- Tests: unit coverage for the skip/handler behavior and the message shape (`src/project-utils.test.ts`), and an integration test asserting `lintGraceProject` returns exactly one `walk.unreadable-directory` warning and continues (`src/grace-lint.test.ts`). The permission-dependent tests are skipped on Windows and when running as root, where permission bits are not enforced.

After the fix, the repro from the issue yields:

```text
Warnings: 1
- [warning] walk.unreadable-directory <project>/blocked — Directory '<project>/blocked' could not be listed (EACCES); its contents were not checked.
```

…and `lint`/`status` exit normally (warnings do not fail the default `--failOn errors` policy).

## Out of scope, deliberately

- Walkers over the `.grace` tree itself (grammar, projections, scope) remain fail-closed: if the governed state is unreadable, refusing to report is the honest behavior, and the issue's scenario assumes a healthy `.grace` tree.
- Unreadable *files* (`readFileSync` EACCES on an individual file) are an adjacent gap with the same shape; this PR follows the issue's suggested shape and handles directories only. Happy to follow up.

## Verification

- `bun run typecheck` — clean
- `bun run test` — 317 pass / 3 skip / 0 fail (4 new tests; skips are the permission-guarded ones only on platforms that cannot enforce permissions — they run on ubuntu CI)
- `bun run validate:cli` — 62 pass / 0 fail
- `bun run ./scripts/validate-marketplace.ts` — PASS
- Manual repro of the issue on a fixture GRACE 4 project: before — both commands abort with `invalid-project`; after — both complete with the named warning (text and `--format json`).
