### PR TITLE
feat(cli): expand default ignored directories across ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,21 @@ An optional `.grace-lint.json` file at the project root (next to `.grace`) contr
 }
 ```
 
-- `ignoredDirs` lists directory names to prune from file collection, on top of the built-in set (`.git`, `node_modules`, `dist`, `build`, `coverage`, `.next`, `.turbo`, `.cache`). Names match at any depth; globs and paths are not supported.
+- `ignoredDirs` lists directory names to prune from file collection, on top of the built-in set below. Names match at any depth; globs and paths are not supported.
 - The file must be a JSON object with supported keys only. Broken JSON, a non-object shape, an unknown key, or a non-array `ignoredDirs` is a `config.*` lint error, and query commands refuse to run until the file is fixed.
 - A directory that cannot be listed (restrictive permissions, sandbox leftovers) is skipped with a `walk.unreadable-directory` warning instead of aborting the run; add its name to `ignoredDirs` to prune it silently. Explain any of these codes with `grace lint --explain <code>`.
+
+Built-in ignored directories:
+
+- VCS metadata: `.git`, `.svn`, `.hg`
+- JavaScript/TypeScript output and caches: `node_modules`, `dist`, `build`, `coverage`, `.next`, `.nuxt`, `.output`, `out`, `.turbo`, `.vite`, `.parcel-cache`, `.svelte-kit`, `.astro`, `storybook-static`, `.cache`, `.yarn`
+- Python bytecode, virtualenvs, and tool caches: `__pycache__`, `venv`, `.venv`, `.tox`, `.nox`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.pyre`, `.pytype`, `htmlcov`, `.eggs`
+- JVM and Rust build output: `target`, `.gradle`, `.idea`
+- Vendored dependencies (Go modules, Ruby bundler, PHP Composer): `vendor`
+- Swift/Apple toolchain output and dependencies: `.build`, `Pods`, `Carthage`, `DerivedData`
+- Dart/Flutter tooling cache: `.dart_tool`
+- Ruby/general scratch space: `tmp`, `.bundle`
+- Editor metadata: `.vscode`
 
 ## Grep-First Navigation
 

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -365,3 +365,39 @@ describe("unreadable directory walking", () => {
     expect(reported).toEqual([]);
   });
 });
+
+describe("default ignored directories", () => {
+  const defaultIgnored = [
+    ".git", ".svn", ".hg",
+    "node_modules", "dist", "build", "coverage", ".next", ".nuxt", ".output", "out", ".turbo",
+    ".vite", ".parcel-cache", ".svelte-kit", ".astro", "storybook-static", ".cache", ".yarn",
+    "__pycache__", "venv", ".venv", ".tox", ".nox", ".pytest_cache", ".mypy_cache", ".ruff_cache",
+    ".pyre", ".pytype", "htmlcov", ".eggs",
+    "target", ".gradle", ".idea",
+    "vendor",
+    ".build", "Pods", "Carthage", "DerivedData",
+    ".dart_tool",
+    "tmp", ".bundle",
+    ".vscode",
+  ];
+
+  it("prunes well-known ecosystem directories by default", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-ignore-"));
+    for (const dir of defaultIgnored) {
+      mkdirSync(path.join(root, dir));
+      writeFileSync(path.join(root, dir, "generated.ts"), "export const generated = true;\n");
+    }
+    writeFileSync(path.join(root, "source.ts"), "export const source = true;\n");
+
+    expect(collectCodeFiles(root, [])).toEqual([path.join(root, "source.ts")]);
+  });
+
+  it("prunes default-ignored names at any depth", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-ignore-depth-"));
+    mkdirSync(path.join(root, "src", "__pycache__"), { recursive: true });
+    writeFileSync(path.join(root, "src", "__pycache__", "cached.ts"), "export const cached = true;\n");
+    writeFileSync(path.join(root, "src", "main.ts"), "export const main = true;\n");
+
+    expect(collectCodeFiles(root, [])).toEqual([path.join(root, "src", "main.ts")]);
+  });
+});

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -51,15 +51,64 @@ export type GovernedFileAnalysis = {
   issues: LintIssue[];
 };
 
+/**
+ * Directory names pruned from every project walk, matched at any depth.
+ * Covers VCS metadata, build output, dependency caches, vendored code,
+ * and tool scratch space across the ecosystems GRACE analyzes.
+ */
 const DEFAULT_IGNORED_DIRS = new Set([
+  // VCS metadata
   ".git",
+  ".svn",
+  ".hg",
+  // JavaScript/TypeScript output and caches
   "node_modules",
   "dist",
   "build",
   "coverage",
   ".next",
+  ".nuxt",
+  ".output",
+  "out",
   ".turbo",
+  ".vite",
+  ".parcel-cache",
+  ".svelte-kit",
+  ".astro",
+  "storybook-static",
   ".cache",
+  ".yarn",
+  // Python bytecode, virtualenvs, tool caches, and coverage reports
+  "__pycache__",
+  "venv",
+  ".venv",
+  ".tox",
+  ".nox",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".ruff_cache",
+  ".pyre",
+  ".pytype",
+  "htmlcov",
+  ".eggs",
+  // JVM and Rust build output, Gradle cache, IDE metadata
+  "target",
+  ".gradle",
+  ".idea",
+  // Vendored dependencies (Go modules, Ruby bundler, PHP Composer)
+  "vendor",
+  // Swift/Apple toolchain output and dependencies
+  ".build",
+  "Pods",
+  "Carthage",
+  "DerivedData",
+  // Dart/Flutter tooling cache
+  ".dart_tool",
+  // Ruby/general scratch space and bundler config
+  "tmp",
+  ".bundle",
+  // Editor metadata
+  ".vscode",
 ]);
 
 


### PR DESCRIPTION
## Problem

Code collection walks every non-ignored directory, so projects in the Python, JVM, Rust, Go, Swift, and Flutter ecosystems pay for scanning virtualenvs, bytecode caches, build output, and vendored dependencies — none of which can carry GRACE markup. This inflates `Files checked`, slows lint/status/query on large projects, and buries real diagnostics.

## What changes

- Extends `DEFAULT_IGNORED_DIRS` (`src/project-utils.ts`) from 8 to 43 names, grouped and commented by ecosystem:
  - VCS metadata: `.svn`, `.hg`
  - JS/TS output and caches: `.nuxt`, `.output`, `out`, `.vite`, `.parcel-cache`, `.svelte-kit`, `.astro`, `storybook-static`, `.yarn`
  - Python: `__pycache__`, `venv`, `.venv`, `.tox`, `.nox`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.pyre`, `.pytype`, `htmlcov`, `.eggs`
  - JVM/Rust: `target`, `.gradle`, `.idea`
  - Vendored dependencies (Go modules, Ruby bundler, PHP Composer): `vendor`
  - Swift/Apple: `.build`, `Pods`, `Carthage`, `DerivedData`
  - Dart/Flutter: `.dart_tool`
  - Ruby/general scratch: `tmp`, `.bundle`
  - Editor metadata: `.vscode`
- Behavioral test pins the full set (one generated code file per ignored name must not be collected) and the at-any-depth matching (`src/project-utils.test.ts`).
- README `Lint Configuration` section now lists the built-in set grouped by ecosystem instead of the old 8-name parenthetical.

## Deliberately not added

- `bin` — Dart projects keep real entrypoint source there, and the Dart adapter is shipped.
- `env` — too common as a real project directory; `venv`/`.venv` cover virtualenvs.
- `ios`/`android` — Flutter projects keep genuine Swift/Kotlin code there.
- `*.egg-info`-style patterns — exact-name matching cannot express them; that is future glob-support material.

Matching semantics are unchanged: directory names at any depth, and `.grace-lint.json` `ignoredDirs` remains the project-level escape hatch in either direction.

## Verification

- `bun run typecheck` — clean
- `bun run test` — 319 pass / 3 skip / 0 fail (2 new tests)
- `bun run validate:cli` — 62 pass / 0 fail
- `bun run ./scripts/validate-marketplace.ts` — PASS
- Manual: `grace lint` on a fixture with `venv/` and `src/__pycache__/` containing code files prunes both silently (`Files checked` unchanged, no warnings).
