### PR TITLE
fix(dart): run analyzer outside package context and tolerate stdout preamble

### DIFF
--- a/src/lint/adapters/dart.test.ts
+++ b/src/lint/adapters/dart.test.ts
@@ -1,7 +1,10 @@
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, test } from "bun:test";
 
-import { createDartAdapter } from "./dart";
+import { createDartAdapter, sanitizeDartAnalyzerOutput } from "./dart";
 
 const hasDart = (() => {
   const result = spawnSync("dart", ["--version"], { stdio: "ignore" });
@@ -60,5 +63,42 @@ describe("DartAdapter", () => {
     expect(result.exports.has("Greeting")).toBe(true);
     expect(result.exports.has("greet")).toBe(true);
     expect(result.exportConfidence).toBe("heuristic");
+  });
+
+  test.skipIf(!hasDart)("analyzes a governed file inside a Dart package context", () => {
+    // Regression for #29: inside a package (pubspec.yaml nearby) `dart run` can
+    // print tool preamble onto stdout. The analyzer must run outside that
+    // context and still return a parsed result.
+    const packageDir = mkdtempSync(path.join(os.tmpdir(), "grace-dart-package-"));
+    writeFileSync(path.join(packageDir, "pubspec.yaml"), "name: grace_fixture\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n");
+    const governedFile = path.join(packageDir, "widget.dart");
+
+    const result = adapter.analyze(governedFile, "class Widget {}\nString build() => 'ok';\n");
+    expect(result.adapterId).toBe("dart");
+    expect(result.exports.has("Widget")).toBe(true);
+    expect(result.exports.has("build")).toBe(true);
+  });
+});
+
+describe("sanitizeDartAnalyzerOutput", () => {
+  const payload = JSON.stringify({ exports: ["Widget"], valueExports: ["Widget"] });
+
+  it("keeps a clean JSON payload unchanged", () => {
+    expect(sanitizeDartAnalyzerOutput(payload)).toBe(payload);
+  });
+
+  it("strips the Dart SDK tool preamble before the JSON", () => {
+    const polluted = `Running build hooks...Running build hooks...Running\n${payload}`;
+    expect(sanitizeDartAnalyzerOutput(polluted)).toBe(payload);
+  });
+
+  it("carves the payload out of surrounding noise on both sides", () => {
+    const polluted = `Resolving dependencies...\n${payload}\nDone.`;
+    expect(sanitizeDartAnalyzerOutput(polluted)).toBe(payload);
+  });
+
+  it("returns the input unchanged when no JSON object is present", () => {
+    expect(sanitizeDartAnalyzerOutput("Running build hooks...")).toBe("Running build hooks...");
+    expect(sanitizeDartAnalyzerOutput("")).toBe("");
   });
 });

--- a/src/lint/adapters/dart.ts
+++ b/src/lint/adapters/dart.ts
@@ -140,8 +140,24 @@ function createEmptyAnalysis(): LanguageAnalysis {
   };
 }
 
+/**
+ * Extracts the analyzer JSON payload from raw stdout. Dart SDK 3.10.8+ can
+ * print tool preamble (e.g. "Running build hooks...") before the JSON when
+ * `dart run` executes inside a package context, so the payload is carved out
+ * instead of parsing the whole stream. Returns the input unchanged when no
+ * JSON object is present, letting JSON.parse surface the original failure.
+ */
+export function sanitizeDartAnalyzerOutput(output: string): string {
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end <= start) {
+    return output;
+  }
+  return output.slice(start, end + 1);
+}
+
 function normalizeResult(output: string): LanguageAnalysis {
-  const parsed = JSON.parse(output) as {
+  const parsed = JSON.parse(sanitizeDartAnalyzerOutput(output)) as {
     exports: string[];
     valueExports: string[];
     typeExports: string[];
@@ -178,10 +194,15 @@ function runDartAnalyzer(filePath: string, text: string): LanguageAnalysis {
   writeFileSync(analyzerFile, DART_ANALYZER_SCRIPT, "utf8");
   try {
     for (const binary of DART_BINARIES) {
+      // Run outside the governed package context: with a pubspec.yaml nearby,
+      // `dart run` can emit tool output ("Running build hooks...") onto stdout
+      // and pollute the analyzer JSON. The script reads the source from stdin
+      // and takes the file path as an argument, so the cwd is irrelevant to it.
       const run = spawnSync(binary, ["run", analyzerFile, filePath], {
         input: Buffer.from(text, "utf8"),
         encoding: "utf8",
         maxBuffer: 1024 * 1024,
+        cwd: temporaryDirectory,
       });
 
       if (run.error) {


### PR DESCRIPTION
## Problem

Addresses the actionable part of #29.

Dart SDK 3.10.8+ can print tool preamble (`Running build hooks...`) onto stdout when `dart run` executes inside a package context. The adapter ran the analyzer with the governed project as cwd and did a bare `JSON.parse` of stdout, so inside a Flutter project every governed Dart file failed with `analysis.adapter-failed`.

## What changes

Two independent guards in `src/lint/adapters/dart.ts`:

1. **Root cause:** the analyzer is spawned with the temp directory as `cwd`, so it never runs in the governed package's context. The script reads source from stdin and takes the file path as an argument, so the cwd is irrelevant to it.
2. **Defense in depth:** a new exported `sanitizeDartAnalyzerOutput` carves the JSON payload (first `{` … last `}`) out of stdout instead of parsing the whole stream, so any future tool output around the payload cannot break analysis. Without a JSON object present the input is returned unchanged, preserving the original failure path.

Not used: the issue's suggested `dart pub run` — it is deprecated and treats the symptom rather than the cause.

## Tests (reproducible)

- Deterministic unit coverage of the sanitizer: clean payload passes through unchanged; the exact `Running build hooks...` preamble from the issue is stripped; noise on both sides is carved out; no-JSON input is returned unchanged (4 tests, run everywhere including Windows CI).
- Package-context regression test: a governed file inside a directory with a `pubspec.yaml` must still analyze cleanly. Guarded by `hasDart`, so it runs on the `dart-adapter` CI job with a real stable Dart SDK and skips where no SDK exists.
- Note: reproducing the literal `Running build hooks...` emission additionally needs a native-assets `hook.yaml` on SDK ≥ 3.10.8; that trigger is SDK-configuration-dependent, so the sanitizer unit tests pin it deterministically instead.

## Verification

- `bun run typecheck` — clean
- `bun test` — 323 pass / 4 skip / 0 fail (skips are the two real-Dart tests on a machine without a Dart SDK; they run in the `dart-adapter` job)
- CLI test set — 62 pass / 0 fail
- `bun run ./scripts/validate-marketplace.ts` — PASS

Not auto-closing #29: part 1 of that report (missing `.dart` extension) does not reproduce on any published 4.x and duplicates the completed #28; the issue should be closed with an explanatory reply once this lands.
