### PR TITLE
feat(lint): cache per-file language analyses across runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Built-in ignored directories:
 - Ruby/general scratch space: `tmp`, `.bundle`
 - Editor metadata: `.vscode`
 
+### Analysis Cache
+
+Successful per-file language analyses are cached across runs, so unchanged governed files are not re-analyzed. Entries are keyed by file content and extension plus a schema version: any file edit or analyzer logic change invalidates the entry automatically, and failed analyses are never cached, so fixing a missing runtime takes effect immediately.
+
+- Location: `$XDG_CACHE_HOME/grace-cli/analysis`, falling back to `~/.cache/grace-cli/analysis`. Override the base directory with `GRACE_CACHE_DIR`.
+- Disable caching with `GRACE_NO_CACHE=1`.
+- The cache lives outside the project: it never touches `.grace` and produces no drift noise.
+
 ## Grep-First Navigation
 
 Prefer this order when narrowing scope:

--- a/src/lint/analysis-cache.test.ts
+++ b/src/lint/analysis-cache.test.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { analyzeGovernedFile } from "../project-utils";
+import { ANALYSIS_CACHE_SCHEMA_VERSION, analysisCacheKey, readCachedAnalysis, writeCachedAnalysis } from "./analysis-cache";
+import type { LanguageAnalysis } from "./types";
+
+function sampleAnalysis(overrides: Partial<LanguageAnalysis> = {}): LanguageAnalysis {
+  return {
+    adapterId: "typescript",
+    exports: new Set(["value", "ExampleType"]),
+    valueExports: new Set(["value"]),
+    typeExports: new Set(["ExampleType"]),
+    localSymbols: new Set(["helper"]),
+    exportConfidence: "exact",
+    hasDefaultExport: false,
+    hasWildcardReExport: false,
+    hasMainEntrypoint: false,
+    directReExportCount: 1,
+    localExportCount: 2,
+    localImplementationCount: 3,
+    usesTestFramework: false,
+    ...overrides,
+  };
+}
+
+function listFilesRecursively(directory: string): string[] {
+  if (!existsSync(directory)) {
+    return [];
+  }
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? listFilesRecursively(entryPath) : [entryPath];
+  });
+}
+
+describe("analysis cache", () => {
+  let cacheDir: string;
+  let savedCacheDir: string | undefined;
+  let savedNoCache: string | undefined;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(path.join(os.tmpdir(), "grace-cache-"));
+    savedCacheDir = process.env.GRACE_CACHE_DIR;
+    savedNoCache = process.env.GRACE_NO_CACHE;
+    delete process.env.GRACE_NO_CACHE;
+    process.env.GRACE_CACHE_DIR = cacheDir;
+  });
+
+  afterEach(() => {
+    if (savedCacheDir === undefined) delete process.env.GRACE_CACHE_DIR;
+    else process.env.GRACE_CACHE_DIR = savedCacheDir;
+    if (savedNoCache === undefined) delete process.env.GRACE_NO_CACHE;
+    else process.env.GRACE_NO_CACHE = savedNoCache;
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("round-trips a successful analysis through the cache", () => {
+    const file = "/project/src/example.ts";
+    const text = "export const value = 1;\n";
+    expect(readCachedAnalysis("typescript", file, text)).toBeNull();
+
+    writeCachedAnalysis("typescript", file, text, sampleAnalysis());
+    const cached = readCachedAnalysis("typescript", file, text);
+
+    expect(cached).not.toBeNull();
+    expect(cached).toEqual(sampleAnalysis());
+    expect([...(cached?.exports ?? [])]).toEqual(["value", "ExampleType"]);
+  });
+
+  it("keys by content and extension, not by path", () => {
+    const text = "export const value = 1;\n";
+    expect(analysisCacheKey("/a/src/example.ts", text)).toBe(analysisCacheKey("/b/elsewhere/example.ts", text));
+    expect(analysisCacheKey("/a/src/example.ts", text)).not.toBe(analysisCacheKey("/a/src/example.js", text));
+    expect(analysisCacheKey("/a/src/example.ts", text)).not.toBe(analysisCacheKey("/a/src/example.ts", `${text}// changed\n`));
+  });
+
+  it("treats schema version mismatches as misses", () => {
+    const file = "/project/src/schema.ts";
+    const text = "export const schema = true;\n";
+    writeCachedAnalysis("typescript", file, text, sampleAnalysis());
+
+    const key = analysisCacheKey(file, text);
+    const entryPath = path.join(cacheDir, "analysis", key.slice(0, 2), `${key}.json`);
+    const stored = JSON.parse(readFileSync(entryPath, "utf8"));
+    expect(stored.schemaVersion).toBe(ANALYSIS_CACHE_SCHEMA_VERSION);
+    writeFileSync(entryPath, JSON.stringify({ ...stored, schemaVersion: ANALYSIS_CACHE_SCHEMA_VERSION + 1 }));
+
+    expect(readCachedAnalysis("typescript", file, text)).toBeNull();
+  });
+
+  it("treats adapter mismatches as misses", () => {
+    const file = "/project/src/adapter.ts";
+    const text = "export const adapter = true;\n";
+    writeCachedAnalysis("typescript", file, text, sampleAnalysis());
+
+    expect(readCachedAnalysis("python", file, text)).toBeNull();
+    expect(readCachedAnalysis("typescript", file, text)).not.toBeNull();
+  });
+
+  it("treats corrupt entries as misses instead of failing", () => {
+    const file = "/project/src/corrupt.ts";
+    const text = "export const corrupt = true;\n";
+    writeCachedAnalysis("typescript", file, text, sampleAnalysis());
+
+    const key = analysisCacheKey(file, text);
+    writeFileSync(path.join(cacheDir, "analysis", key.slice(0, 2), `${key}.json`), "not-json{{{");
+
+    expect(readCachedAnalysis("typescript", file, text)).toBeNull();
+  });
+
+  it("does not read or write when GRACE_NO_CACHE is set", () => {
+    process.env.GRACE_NO_CACHE = "1";
+    const file = "/project/src/disabled.ts";
+    const text = "export const disabled = true;\n";
+
+    writeCachedAnalysis("typescript", file, text, sampleAnalysis());
+    expect(readCachedAnalysis("typescript", file, text)).toBeNull();
+    expect(listFilesRecursively(cacheDir)).toEqual([]);
+  });
+
+  it("caches governed-file analysis across repeated runs", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-cache-fixture-"));
+    const file = path.join(root, "src", "example.ts");
+    const text = `// START_MODULE_CONTRACT
+// PURPOSE: Cache fixture.
+// SCOPE: Test-only.
+// DEPENDS: none
+// LINKS: M-CACHE
+// ROLE: RUNTIME
+// MAP_MODE: EXPORTS
+// END_MODULE_CONTRACT
+// START_MODULE_MAP
+//   value - Runtime value.
+// END_MODULE_MAP
+export const value = 1;
+`;
+    try {
+      const first = analyzeGovernedFile(root, file, text);
+      const entries = listFilesRecursively(path.join(cacheDir, "analysis")).filter((entry) => entry.endsWith(".json"));
+      expect(entries).toHaveLength(1);
+
+      const second = analyzeGovernedFile(root, file, text);
+      expect(second.language).toEqual(first.language);
+      expect(second.language?.exportConfidence).toBe("exact");
+      // The hit must not create another entry for the same content.
+      expect(listFilesRecursively(path.join(cacheDir, "analysis")).filter((entry) => entry.endsWith(".json"))).toEqual(entries);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps unrelated cache files out of the governed project", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-cache-isolation-"));
+    try {
+      analyzeGovernedFile(root, path.join(root, "plain.ts"), "export const plain = 1;\n");
+      const leftovers = listFilesRecursively(root).filter((entry) => entry.includes("cache"));
+      expect(leftovers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lint/analysis-cache.ts
+++ b/src/lint/analysis-cache.ts
@@ -1,0 +1,143 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { LanguageAnalysis } from "./types";
+
+/**
+ * Bump whenever the cached shape or adapter analysis semantics change.
+ * Entries written by a different schema version are treated as cache misses,
+ * so logic changes invalidate the whole cache without any cleanup step.
+ */
+export const ANALYSIS_CACHE_SCHEMA_VERSION = 1;
+
+type CachedAnalysisRecord = {
+  schemaVersion: number;
+  adapterId: string;
+  analysis: {
+    adapterId: string;
+    exports: string[];
+    valueExports: string[];
+    typeExports: string[];
+    localSymbols: string[];
+    exportConfidence: "exact" | "heuristic";
+    hasDefaultExport: boolean;
+    hasWildcardReExport: boolean;
+    hasMainEntrypoint: boolean;
+    directReExportCount: number;
+    localExportCount: number;
+    localImplementationCount: number;
+    usesTestFramework: boolean;
+  };
+};
+
+/**
+ * Resolves the analysis cache directory. `GRACE_CACHE_DIR` overrides the base
+ * directory; otherwise `$XDG_CACHE_HOME/grace-cli` (falling back to
+ * `~/.cache/grace-cli`) is used. Returns null when caching is disabled via
+ * `GRACE_NO_CACHE`, which makes every read miss and every write a no-op.
+ */
+function resolveAnalysisCacheDir(): string | null {
+  if (process.env.GRACE_NO_CACHE) {
+    return null;
+  }
+  const override = process.env.GRACE_CACHE_DIR?.trim();
+  const base = override && override.length > 0
+    ? override
+    : path.join(process.env.XDG_CACHE_HOME?.trim() || path.join(os.homedir(), ".cache"), "grace-cli");
+  return path.join(base, "analysis");
+}
+
+/** Content-addressed key: file content plus extension, independent of path. */
+export function analysisCacheKey(filePath: string, text: string): string {
+  return createHash("sha256").update(`${path.extname(filePath)}\u0000${text}`).digest("hex");
+}
+
+function cacheEntryPath(cacheDir: string, key: string): string {
+  return path.join(cacheDir, key.slice(0, 2), `${key}.json`);
+}
+
+function toCachedRecord(adapterId: string, analysis: LanguageAnalysis): CachedAnalysisRecord {
+  return {
+    schemaVersion: ANALYSIS_CACHE_SCHEMA_VERSION,
+    adapterId,
+    analysis: {
+      adapterId: analysis.adapterId,
+      exports: [...analysis.exports],
+      valueExports: [...analysis.valueExports],
+      typeExports: [...analysis.typeExports],
+      localSymbols: [...analysis.localSymbols],
+      exportConfidence: analysis.exportConfidence,
+      hasDefaultExport: analysis.hasDefaultExport,
+      hasWildcardReExport: analysis.hasWildcardReExport,
+      hasMainEntrypoint: analysis.hasMainEntrypoint,
+      directReExportCount: analysis.directReExportCount,
+      localExportCount: analysis.localExportCount,
+      localImplementationCount: analysis.localImplementationCount,
+      usesTestFramework: analysis.usesTestFramework,
+    },
+  };
+}
+
+function fromCachedRecord(record: CachedAnalysisRecord["analysis"]): LanguageAnalysis {
+  return {
+    adapterId: record.adapterId,
+    exports: new Set(record.exports ?? []),
+    valueExports: new Set(record.valueExports ?? []),
+    typeExports: new Set(record.typeExports ?? []),
+    localSymbols: new Set(record.localSymbols ?? []),
+    exportConfidence: record.exportConfidence ?? "heuristic",
+    hasDefaultExport: Boolean(record.hasDefaultExport),
+    hasWildcardReExport: Boolean(record.hasWildcardReExport),
+    hasMainEntrypoint: Boolean(record.hasMainEntrypoint),
+    directReExportCount: Number(record.directReExportCount ?? 0),
+    localExportCount: Number(record.localExportCount ?? 0),
+    localImplementationCount: Number(record.localImplementationCount ?? 0),
+    usesTestFramework: Boolean(record.usesTestFramework),
+  };
+}
+
+/**
+ * Returns the cached analysis for this adapter/file/content, or null on a miss.
+ * Any read, parse, schema, or adapter mismatch is a miss, never an error: the
+ * cache is a speedup and must not be able to break linting.
+ */
+export function readCachedAnalysis(adapterId: string, filePath: string, text: string): LanguageAnalysis | null {
+  const cacheDir = resolveAnalysisCacheDir();
+  if (!cacheDir) {
+    return null;
+  }
+  try {
+    const raw = readFileSync(cacheEntryPath(cacheDir, analysisCacheKey(filePath, text)), "utf8");
+    const parsed = JSON.parse(raw) as CachedAnalysisRecord;
+    if (parsed.schemaVersion !== ANALYSIS_CACHE_SCHEMA_VERSION || parsed.adapterId !== adapterId) {
+      return null;
+    }
+    return fromCachedRecord(parsed.analysis);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort write of one successful analysis. Failures (permissions, disk,
+ * concurrent runs) are swallowed; atomic rename keeps torn reads impossible.
+ * Errors thrown by adapters must never reach this function, so environment
+ * failures are not cached.
+ */
+export function writeCachedAnalysis(adapterId: string, filePath: string, text: string, analysis: LanguageAnalysis): void {
+  const cacheDir = resolveAnalysisCacheDir();
+  if (!cacheDir) {
+    return;
+  }
+  try {
+    const target = cacheEntryPath(cacheDir, analysisCacheKey(filePath, text));
+    mkdirSync(path.dirname(target), { recursive: true });
+    const temporary = `${target}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(toCachedRecord(adapterId, analysis)));
+    renameSync(temporary, target);
+  } catch {
+    // The cache is an optimization; never fail linting because of it.
+  }
+}

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -1,6 +1,7 @@
 import { type Dirent, existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { ADAPTER_BACKED_EXTENSIONS, CODE_EXTENSIONS, LANGUAGE_ADAPTERS } from "./language-registry";
+import { readCachedAnalysis, writeCachedAnalysis } from "./lint/analysis-cache";
 import { LanguageRuntimeMissingError, type LanguageAnalysis, type LintIssue, type MapMode, type ModuleRole } from "./lint/types";
 
 export type TextSection = {
@@ -457,7 +458,15 @@ export function analyzeGovernedFile(root: string, filePath: string, text: string
   let language: LanguageAnalysis | null = null;
   if (adapter) {
     try {
-      language = adapter.analyze(filePath, text);
+      // Successful analyses are content-cached across runs; failures stay
+      // uncached so environment fixes take effect immediately.
+      const cached = readCachedAnalysis(adapter.id, filePath, text);
+      if (cached) {
+        language = cached;
+      } else {
+        language = adapter.analyze(filePath, text);
+        writeCachedAnalysis(adapter.id, filePath, text, language);
+      }
     } catch (error) {
       issues.push(markupIssue(
         "error",


### PR DESCRIPTION
## Problem

Adapter analysis is the expensive part of linting governed files: the Python and Dart adapters spawn a subprocess per file, and every run re-does the work for files that did not change. On repeated lints (dev loops, CI re-runs) that cost is paid for identical content every time. Implements the cache item from the #29 discussion, generalized to every language adapter.

## What changes

A content-addressed analysis cache behind the single `adapter.analyze()` seam in `analyzeGovernedFile` (`src/lint/analysis-cache.ts`, ~140 lines):

- **Key:** `sha256(file content + extension)` plus a `ANALYSIS_CACHE_SCHEMA_VERSION` constant stored in each entry. File edits change the hash; analyzer logic changes bump the version and invalidate everything without cleanup. The extension in the key covers path-dependent adapter behavior (TS script kind) while staying stable across checkouts and machines.
- **Successes only:** adapter failures and `LanguageRuntimeMissingError` are never cached, so installing a missing runtime fixes linting immediately.
- **Storage:** `$XDG_CACHE_HOME/grace-cli/analysis` (fallback `~/.cache/grace-cli/analysis`), base dir overridable via `GRACE_CACHE_DIR`, disabled via `GRACE_NO_CACHE=1`. Deliberately outside the project: no writes into governed `.grace` state, no drift-detection noise, no gitignore burden.
- **Best-effort I/O:** any read/parse/schema/adapter mismatch is a miss; writes go through temp file + atomic rename (parallel lint runs are a legitimate GRACE scenario); cache problems can never fail a lint.

README gains an `Analysis Cache` subsection next to `Lint Configuration`.

## Tests (8 new)

- Round-trip equivalence (Sets reconstructed, all fields preserved)
- Key semantics: content+extension based, path-independent, changes with content or extension
- Schema-version mismatch → miss; adapter mismatch → miss
- Corrupt cache entry → miss, not a failure
- `GRACE_NO_CACHE=1` → no reads, no writes
- `analyzeGovernedFile` repeat run: one entry created, second run hits it, results equal
- Project isolation: no cache files ever land inside the project tree

## Verification

- `bun run typecheck` — clean
- `bun test` — 331 pass / 4 skip / 0 fail
- CLI test set — 62 pass / 0 fail
- `bun run ./scripts/validate-marketplace.ts` — PASS
- Manual: lint of a fixture project with `GRACE_CACHE_DIR` override creates exactly one entry on run 1 and reuses it on run 2; default path populates `~/.cache/grace-cli/analysis` during the suite.

## Notes

- The TS adapter is in-process, so the cache saves CPU rather than spawns there; the dominant win is Python/Dart subprocess elimination on unchanged files.
- XML validation, projections, and the file walk are intentionally not cached in this version: cheaper work, harder invalidation. The key design leaves room to extend if measurements ever justify it.
