### PR TITLE
chore: prepare 4.0.5 stable release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "GRACE (Graph-RAG Anchored Code Engineering) - a methodology by Vladimir Ivanov for contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification",
-    "version": "4.0.4"
+    "version": "4.0.5"
   },
   "plugins": [
     {
       "name": "grace",
       "source": "./plugins/grace",
       "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "author": {
         "name": "osovv",
         "url": "https://github.com/osovv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## <small>4.0.5 (2026-08-23)</small>
+
+### Summary
+
+Grace CLI 4.0.5 makes linting faster, more robust, and less noisy across ecosystems. The default ignored-directory list grows to 64 well-known tooling, build-output, and test-report names (covering Playwright, Allure, Newman, Cucumber, Stryker, Python, and JavaScript/TypeScript tooling), so grace lint automatically skips generated artifacts without extra configuration. Repeated lint runs and CI re-runs are now faster thanks to a content-addressed cache of per-file language analyses that lives outside the project, never touches governed .grace state, and invalidates automatically when files change. Reliability fixes include skipping unreadable directories with a warning instead of aborting the whole command, fixing Dart analysis for Flutter projects where the SDK emits tool preamble on stdout, and correctly crediting runtime log-marker evidence from Go, Java, and C# loggers in addition to JavaScript. The optional .grace-lint.json configuration file is now documented for projects that need custom ignore rules.
+
+* feat(cli): expand default ignored directories across ecosystems ([3019de6](https://github.com/osovv/grace-marketplace/commit/3019de6))
+* feat(cli): ignore Newman, Cucumber, Stryker, and remaining tool output ([56f2745](https://github.com/osovv/grace-marketplace/commit/56f2745))
+* feat(cli): ignore test report artifacts and remaining ecosystem directories ([69da5f6](https://github.com/osovv/grace-marketplace/commit/69da5f6))
+* feat(lint): cache per-file language analyses across runs ([47d8f92](https://github.com/osovv/grace-marketplace/commit/47d8f92))
+* fix(cli): skip unreadable directories with a warning instead of aborting ([b0f12be](https://github.com/osovv/grace-marketplace/commit/b0f12be)), closes [#31](https://github.com/osovv/grace-marketplace/issues/31)
+* fix(dart): run analyzer outside package context and tolerate stdout preamble ([bf98471](https://github.com/osovv/grace-marketplace/commit/bf98471)), closes [#29](https://github.com/osovv/grace-marketplace/issues/29)
+* fix(lint): credit log markers emitted by non-JS loggers (e.g. Go or Java) ([b9d7507](https://github.com/osovv/grace-marketplace/commit/b9d7507))
+* docs(cli): document .grace-lint.json configuration ([a14dbc6](https://github.com/osovv/grace-marketplace/commit/a14dbc6))
+
 ## <small>4.0.4 (2026-07-27)</small>
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository ships the GRACE skills plus the optional `grace` CLI. It is a packaging and distribution repository, not an end-user application.
 
-Current packaged version: `4.0.4`
+Current packaged version: `4.0.5`
 
 ## What This Repository Ships
 

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,6 +1,6 @@
 name: grace
 description: "GRACE (Graph-RAG Anchored Code Engineering) - contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification"
-version: 4.0.4
+version: 4.0.5
 author: osovv
 license: MIT
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osovv/grace-cli",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation with a Bun-powered grace binary.",
   "license": "MIT",
   "homepage": "https://github.com/osovv/grace-marketplace#readme",

--- a/plugins/grace/.claude-plugin/plugin.json
+++ b/plugins/grace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grace",
   "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "author": {
     "name": "osovv",
     "url": "https://github.com/osovv"

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -11,7 +11,7 @@ import { verificationCommand } from "./grace-verification";
 const main = defineCommand({
   meta: {
     name: "grace",
-    version: "4.0.4",
+    version: "4.0.5",
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {


### PR DESCRIPTION
Prepare @osovv/grace-cli 4.0.5 for stable publication. After required checks pass and the pull request is merged, run `bun run release:finalize 4.0.5` from clean synchronized main to create and push the immutable release tag.