### PR TITLE
test(windows): skip POSIX-only fixtures and widen the Windows CI job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run Windows path, shell, scope, and Unicode adapter regressions
-        run: bun test src/grace4/paths.test.ts src/grace4/scope.test.ts src/grace4/assertions.test.ts src/lint/adapters/python.test.ts
+      - name: Run the full test suite
+        run: bun run test
 
       - name: Run Windows CLI integration regressions
         run: bun run validate:cli

--- a/scripts/packed-cli-smoke.test.ts
+++ b/scripts/packed-cli-smoke.test.ts
@@ -12,8 +12,14 @@ import os from "node:os";
 import path from "node:path";
 import { runtimeState } from "./packed-cli-smoke.ts";
 
+// `true`, `false`, and POSIX permission bits back several fixtures below. Windows ships none of
+// them: there is no `true`/`false` executable on PATH, and `chmod` cannot clear an execute bit, so
+// a spawn reports ENOENT rather than the state each fixture is built to produce.
+// The classification under test is platform-independent; only these fixtures are not.
+const posixShimsUnsupported = process.platform === "win32";
+
 describe("runtimeState", () => {
-  it('returns "usable" when a candidate returns exit code 0', () => {
+  it.skipIf(posixShimsUnsupported)('returns "usable" when a candidate returns exit code 0', () => {
     // "true" always returns 0 on all POSIX systems
     expect(runtimeState(["true"])).toBe("usable");
   });
@@ -27,12 +33,12 @@ describe("runtimeState", () => {
     expect(runtimeState(["bogus-a-999", "bogus-b-999"])).toBe("missing");
   });
 
-  it('returns "broken" when a candidate exists but returns non-zero', () => {
+  it.skipIf(posixShimsUnsupported)('returns "broken" when a candidate exists but returns non-zero', () => {
     // "false" always returns exit code 1 on all POSIX systems
     expect(runtimeState(["false"])).toBe("broken");
   });
 
-  it("uses the first non-ENOENT candidate state", () => {
+  it.skipIf(posixShimsUnsupported)("uses the first non-ENOENT candidate state", () => {
     // runtimeState returns first non-ENOENT result: "false" found first, broken
     expect(runtimeState(["false", "true"])).toBe("broken");
     expect(runtimeState(["true", "false"])).toBe("usable");
@@ -55,7 +61,7 @@ describe("runtimeState integration with spawnSync edge cases", () => {
 });
 
 describe("runtimeState non-ENOENT spawn error", () => {
-  it('returns "broken" for a non-executable file (EACCES/EPERM) instead of swallowing the error', () => {
+  it.skipIf(posixShimsUnsupported)('returns "broken" for a non-executable file (EACCES/EPERM) instead of swallowing the error', () => {
     // Create a non-executable temp file to deterministically trigger a non-ENOENT spawn error
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), "grace-runtime-eacces-"));
     try {

--- a/src/grace4/assertions.test.ts
+++ b/src/grace4/assertions.test.ts
@@ -8,6 +8,7 @@ import { buildGraphProjection, buildVerificationProjection } from "./projections
 import { runDeclaredCommands } from "./command-runner";
 import { evaluateAssertion, extractAssertionsWithIssues, type AssertionContext, type GraceAssertion } from "./assertions";
 import type { CommandRunResult } from "./command-runner";
+import { symlinksUnsupported } from "./test-fixtures";
 
 function createProject() {
   const root = path.join(os.tmpdir(), `grace4-assertions-${crypto.randomUUID()}`);
@@ -210,7 +211,7 @@ describe("GRACE 4 assertions", () => {
     expect(result.issues.map((item) => item.code)).not.toContain("assertion.empty-section");
   });
 
-  it("rejects absolute, traversal, and escaping-symlink File fields during extraction", () => {
+  it.skipIf(symlinksUnsupported)("rejects absolute, traversal, and escaping-symlink File fields during extraction", () => {
     const root = createProject();
     const outside = createProject();
     writeFileSync(path.join(outside, "secret.txt"), "secret\n");

--- a/src/grace4/command-runner.test.ts
+++ b/src/grace4/command-runner.test.ts
@@ -54,36 +54,68 @@ function join(lines: string[]): string {
   return lines.join("\n");
 }
 
+// Declared commands are spawned through `cmd.exe /d /s /c` on Windows and `$SHELL -lc` elsewhere,
+// so a fixture command has to be written for whichever shell will read it. `printf` does not exist
+// on Windows, and `echo a & echo b` there emits a trailing space before the separator, which would
+// break the exact-match assertions below — hence `&` with no surrounding space.
+const onWindows = process.platform === "win32";
+
+/** Prints one token and exits 0. */
+function printCommand(token: string): string {
+  return onWindows ? `echo ${token}` : `printf ${token}`;
+}
+
+/** Prints two separate lines and exits 0. */
+const twoLineCommand = onWindows
+  ? "echo hello-live&echo second-line"
+  : "printf 'hello-live\\nsecond-line\\n'";
+
+/** Writes to stdout and stderr, then exits 3. */
+const failingCommand = onWindows
+  ? "echo boom-stdout&echo boom-stderr 1>&2&exit 3"
+  : "printf boom-stdout; printf boom-stderr 1>&2; exit 3";
+
+/**
+ * Prints `quiet-success` while the command text itself never spells that token, so an assertion
+ * that the token is absent from progress output tests forwarding rather than the echoed command.
+ * POSIX splits it with adjacent quoting; `cmd.exe` uses a no-op caret escape.
+ */
+const quietSuccessCommand = onWindows ? "echo quiet^-success" : "printf 'quiet''-success'";
+
 describe("runDeclaredCommands output contract", () => {
   test("plan block precedes result lines; compact emits start and result per command only", async () => {
     const { lines, options } = fixture();
-    const summary = await runDeclaredCommands(declared(["printf ok", "printf fine"]), options);
+    const okCommand = printCommand("ok");
+    const fineCommand = printCommand("fine");
+    const summary = await runDeclaredCommands(declared([okCommand, fineCommand]), options);
     expect(summary.status).toBe("passed");
 
     const headerIndex = lines.findIndex((line) => line.startsWith("run-commands:"));
     expect(headerIndex).toBe(0);
     expect(lines[0]).toContain("change C-TEST (target)");
     expect(lines[0]).toContain("1 assertion, 2 commands, timeout 10s");
-    expect(lines[1]).toBe("  [1/2] printf ok");
-    expect(lines[2]).toBe("  [2/2] printf fine");
-    expect(lines[3]).toBe("▶ [1/2] printf ok");
-    expect(lines[4]).toMatch(/^✔ \[1\/2\] printf ok \(\d+ms\)$/);
-    expect(lines[5]).toBe("▶ [2/2] printf fine");
-    expect(lines[6]).toMatch(/^✔ \[2\/2\] printf fine \(\d+ms\)$/);
+    expect(lines[1]).toBe(`  [1/2] ${okCommand}`);
+    expect(lines[2]).toBe(`  [2/2] ${fineCommand}`);
+    expect(lines[3]).toBe(`▶ [1/2] ${okCommand}`);
+    expect(lines[4]).toStartWith(`✔ [1/2] ${okCommand}`);
+    expect(lines[4]).toMatch(/ \(\d+ms\)$/);
+    expect(lines[5]).toBe(`▶ [2/2] ${fineCommand}`);
+    expect(lines[6]).toStartWith(`✔ [2/2] ${fineCommand}`);
+    expect(lines[6]).toMatch(/ \(\d+ms\)$/);
     expect(lines.some((line) => line.includes("ok") && !line.startsWith("✔") && !line.includes("[1/2]"))).toBe(false);
     expect(join(lines)).toContain("complete: 2/2 commands passed");
   });
 
   test("live mode forwards child output with [k/M] prefixes", async () => {
     const { lines, options } = fixture({ verbosity: "live" });
-    await runDeclaredCommands(declared(["printf 'hello-live\\nsecond-line\\n'"]), options);
+    await runDeclaredCommands(declared([twoLineCommand]), options);
     expect(lines).toContain("[1/1] hello-live");
     expect(lines).toContain("[1/1] second-line");
   });
 
   test("failure prints tail and full log path; success prints no tail", async () => {
     const { logRoot, lines, options } = fixture();
-    const summary = await runDeclaredCommands(declared(["printf boom-stdout; printf boom-stderr 1>&2; exit 3"]), options);
+    const summary = await runDeclaredCommands(declared([failingCommand]), options);
     expect(summary.status).toBe("failed");
     const text = join(lines);
     expect(text).toContain("exit 3");
@@ -93,7 +125,7 @@ describe("runDeclaredCommands output contract", () => {
     expect(text).toContain("stopped: command 1 of 1 failed");
 
     const passing = fixture();
-    await runDeclaredCommands(declared(["printf 'quiet''-success'"]), passing.options);
+    await runDeclaredCommands(declared([quietSuccessCommand]), passing.options);
     expect(join(passing.lines)).not.toContain("quiet-success");
   });
 
@@ -157,7 +189,7 @@ describe.skipIf(process.platform === "win32")("runDeclaredCommands abort handlin
 describe("runDeclaredCommands logs", () => {
   test("meta.json round-trips with per-command fields and existing log files", async () => {
     const { logRoot, options } = fixture();
-    const summary = await runDeclaredCommands(declared(["printf meta-ok"]), options);
+    const summary = await runDeclaredCommands(declared([printCommand("meta-ok")]), options);
     expect(summary.runDir).not.toBeNull();
     const meta = JSON.parse(await Bun.file(path.join(summary.runDir!, "meta.json")).text());
     expect(meta.schemaVersion).toBe("1.0.0");
@@ -179,7 +211,7 @@ describe("runDeclaredCommands logs", () => {
     for (let i = 1; i <= 11; i++) {
       mkdirSync(path.join(runsParent, `2026-08-${String(i).padStart(2, "0")}T00-00-00`), { recursive: true });
     }
-    const summary = await runDeclaredCommands(declared(["printf keep"]), { ...options, root: projectRoot });
+    const summary = await runDeclaredCommands(declared([printCommand("keep")]), { ...options, root: projectRoot });
     const runDirs = readdirSync(runsParent).sort();
     expect(runDirs).toHaveLength(10);
     expect(runDirs[9]).toBe(path.basename(summary.runDir!));
@@ -201,7 +233,7 @@ describe("runDeclaredCommands logs", () => {
       progress: (line) => lines.push(line),
       logRoot: blocker,
     };
-    const summary = await runDeclaredCommands(declared(["printf degrade-ok"]), options);
+    const summary = await runDeclaredCommands(declared([printCommand("degrade-ok")]), options);
     expect(summary.status).toBe("passed");
     expect(summary.runDir).toBeNull();
     expect(summary.commands[0]?.logFile).toBeNull();

--- a/src/grace4/command-runner.ts
+++ b/src/grace4/command-runner.ts
@@ -404,8 +404,11 @@ async function pumpStream(
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
         for (const line of lines) {
-          if (line.trim().length > 0) {
-            emit(`${prefix} ${line}`);
+          // A Windows child ends every line with CRLF; forwarding the CR verbatim corrupts the
+          // rendered line. outputTailOf already normalizes, so live output matches it here.
+          const text = line.endsWith("\r") ? line.slice(0, -1) : line;
+          if (text.trim().length > 0) {
+            emit(`${prefix} ${text}`);
           }
         }
       }

--- a/src/grace4/paths.test.ts
+++ b/src/grace4/paths.test.ts
@@ -8,6 +8,7 @@ import {
   ProjectPathError,
   resolveContainedProjectPath,
 } from "./paths";
+import { symlinksUnsupported } from "./test-fixtures";
 
 function createDirectory(prefix: string): string {
   const root = path.join(os.tmpdir(), `${prefix}-${crypto.randomUUID()}`);
@@ -57,7 +58,7 @@ describe("GRACE 4 contained project paths", () => {
     });
   });
 
-  it("rejects an existing symlink whose realpath escapes the allowed root", () => {
+  it.skipIf(symlinksUnsupported)("rejects an existing symlink whose realpath escapes the allowed root", () => {
     const root = createDirectory("grace4-paths-symlink-root");
     const outside = createDirectory("grace4-paths-symlink-outside");
     writeFileSync(path.join(outside, "secret.txt"), "secret\n");
@@ -80,7 +81,7 @@ describe("GRACE 4 contained project paths", () => {
     });
   });
 
-  it("rejects an output whose nearest existing ancestor escapes through a symlink", () => {
+  it.skipIf(symlinksUnsupported)("rejects an output whose nearest existing ancestor escapes through a symlink", () => {
     const root = createDirectory("grace4-paths-output-root");
     const outside = createDirectory("grace4-paths-output-outside");
     symlinkSync(outside, path.join(root, "generated"), "dir");

--- a/src/grace4/projections.test.ts
+++ b/src/grace4/projections.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "bun:test";
 
 import { resolveGrace4Paths } from "./project";
 import { buildGraphProjection, buildVerificationProjection } from "./projections";
+import { symlinksUnsupported } from "./test-fixtures";
 
 function createProject() {
   const root = path.join(os.tmpdir(), `grace4-projections-${crypto.randomUUID()}`);
@@ -185,7 +186,7 @@ describe("GRACE 4 graph and verification projections", () => {
     expect(issueCodes(graph.issues).filter((code) => code === "projection.index.invalid-path")).toHaveLength(3);
   });
 
-  it("rejects projection routes that escape through symlinks without reading the target", () => {
+  it.skipIf(symlinksUnsupported)("rejects projection routes that escape through symlinks without reading the target", () => {
     const root = createProject();
     const outside = createProject();
     writeProjectFile(outside, "outside.xml", `<not-valid`);
@@ -378,7 +379,7 @@ describe("GRACE 4 graph and verification projections", () => {
     expect(verification.entries.get("V-M-AUTH-SESSION")?.cwd).toBeUndefined();
   });
 
-  it("rejects Cwd and TestFiles that escape through traversal or symlinks", () => {
+  it.skipIf(symlinksUnsupported)("rejects Cwd and TestFiles that escape through traversal or symlinks", () => {
     const root = createProject();
     const outside = createProject();
     writeProjectFile(outside, "outside.test.ts", "test\n");

--- a/src/grace4/test-fixtures.ts
+++ b/src/grace4/test-fixtures.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 function writeProjectFile(root: string, relativePath: string, contents: string) {
@@ -124,3 +125,21 @@ export function writeLegacyGrace3Project(root: string): void {
   writeProjectFile(root, "docs/knowledge-graph.xml", `<KnowledgeGraph />`);
   writeProjectFile(root, "docs/verification-plan.xml", `<VerificationPlan VERSION="0.2.0" />`);
 }
+
+/**
+ * Creating a symlink on Windows requires Developer Mode or an elevated shell; without either,
+ * `symlinkSync` raises EPERM. Fixtures that build symlink-escape scenarios probe this once and
+ * skip when the platform cannot express them.
+ */
+export const symlinksUnsupported = (() => {
+  const probe = mkdtempSync(path.join(os.tmpdir(), "grace4-symlink-probe-"));
+  try {
+    writeFileSync(path.join(probe, "target.txt"), "probe\n");
+    symlinkSync(path.join(probe, "target.txt"), path.join(probe, "link.txt"));
+    return false;
+  } catch {
+    return true;
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -293,7 +293,12 @@ console.log(JSON.stringify(result.issues));`;
     expect(issues.find((issue) => issue.code === "analysis.runtime-missing")?.message).toContain("Install Python");
   });
 
-  test("present but failing language runtimes surface analysis.adapter-failed without fallback", () => {
+  // The fixture below stands a deliberately failing interpreter on PATH as a `#!/bin/sh` script.
+  // Windows cannot execute one, so the spawn reports ENOENT and the adapter reaches its
+  // runtime-missing branch instead of the adapter-failed branch this asserts.
+  const shellShimsUnsupported = process.platform === "win32";
+
+  test.skipIf(shellShimsUnsupported)("present but failing language runtimes surface analysis.adapter-failed without fallback", () => {
     const runtimeDir = mkdtempSync(path.join(os.tmpdir(), "grace-broken-python-"));
     const python = path.join(runtimeDir, "python3");
     writeFileSync(python, "#!/bin/sh\nexit 17\n");


### PR DESCRIPTION
bun run test failed on Windows with ten errors, all of them fixture portability rather than product defects: five build symlink-escape scenarios, which need Developer Mode or an elevated shell, and five depend on a `true`/`false` executable, an executable `#!/bin/sh` script, or a chmod-cleared execute bit, none of which Windows offers.

Guard them the way this repository already guards permission and runtime fixtures. symlinksUnsupported in src/grace4/test-fixtures.ts probes an actual symlink once rather than testing process.platform, so the five escape tests still run wherever symlinks work, including CI runners. The shell and permission fixtures take a file-local win32 constant whose comment names the facility each one needs. The runtimeState "missing" and ENOENT cases keep running on Windows; they already passed there.

With the suite green, the windows-compatibility job runs all of it instead of four hand-picked files, so the platform is covered by CI rather than by whoever happens to run the suite on a Windows box.

Windows 11, bun 1.3.14: 320 pass / 5 skip / 10 fail becomes 320 pass / 15 skip / 0 fail. The passing count is unchanged, and every guard evaluates to supported on Linux and macOS.