### PR TITLE
chore: prepare 4.0.7 stable release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "GRACE (Graph-RAG Anchored Code Engineering) - a methodology by Vladimir Ivanov for contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification",
-    "version": "4.0.6"
+    "version": "4.0.7"
   },
   "plugins": [
     {
       "name": "grace",
       "source": "./plugins/grace",
       "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "author": {
         "name": "osovv",
         "url": "https://github.com/osovv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## <small>4.0.7 (2026-08-29)</small>
+
+### Summary
+
+Release 4.0.7 upgrades GRACE plan linting so a task's `DependsOn` element can list multiple predecessors using comma-separated text, space-separated text, child anchor tags, or the legacy child-text form. This lets plans express their true dependency DAG instead of forcing independent tasks into artificial linear chains, and validation now catches unknown, duplicate, self, and cyclic dependencies instead of silently dropping them, with error hints pointing to the canonical comma-separated form. The grace-plan skill documentation and change plan template were updated to reflect the multi-dependency contract.
+
+* feat(lint): accept multiple task dependencies in DependsOn ([72012f0](https://github.com/osovv/grace-marketplace/commit/72012f0))
+
 ## <small>4.0.6 (2026-08-29)</small>
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository ships the GRACE skills plus the optional `grace` CLI. It is a packaging and distribution repository, not an end-user application.
 
-Current packaged version: `4.0.6`
+Current packaged version: `4.0.7`
 
 ## What This Repository Ships
 

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,6 +1,6 @@
 name: grace
 description: "GRACE (Graph-RAG Anchored Code Engineering) - contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification"
-version: 4.0.6
+version: 4.0.7
 author: osovv
 license: MIT
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osovv/grace-cli",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation with a Bun-powered grace binary.",
   "license": "MIT",
   "homepage": "https://github.com/osovv/grace-marketplace#readme",

--- a/plugins/grace/.claude-plugin/plugin.json
+++ b/plugins/grace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grace",
   "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "author": {
     "name": "osovv",
     "url": "https://github.com/osovv"

--- a/plugins/grace/skills/grace/grace-plan/SKILL.md
+++ b/plugins/grace/skills/grace/grace-plan/SKILL.md
@@ -26,7 +26,7 @@ description: Read an approved GRACE 4 GraceChangeSpec and optional design contex
 </approved_plan_immutability>
 
 <must_do>
-Produce `plan.xml` from `references/change-plan-template.xml` as draft unless the user explicitly approves the completed plan. Require a matching `C-*` wrapper, meaningful intent, non-empty machine-checkable baseline and target assertions, explicit durable and observed scopes, and unique acyclic `T-NNN` tasks. A scope with no writes must use an explicit `<None />` marker; prose such as "none" is invalid. Every task has one `Title`, one `DependsOn`, non-empty acceptance criteria, and non-empty verification commands. Surface stale-state and coexistence warnings, and reject unsupported scope glob syntax instead of guessing.
+Produce `plan.xml` from `references/change-plan-template.xml` as draft unless the user explicitly approves the completed plan. Require a matching `C-*` wrapper, meaningful intent, non-empty machine-checkable baseline and target assertions, explicit durable and observed scopes, and unique acyclic `T-NNN` tasks. A scope with no writes must use an explicit `<None />` marker; prose such as "none" is invalid. Every task has one `Title`, one `DependsOn` element listing zero or more predecessors as canonical comma-separated `T-NNN` values (for example `<DependsOn>T-001, T-002</DependsOn>`), non-empty acceptance criteria, and non-empty verification commands. Dependencies form a directed acyclic graph: list only true predecessors and never linearize independent tasks into a chain to express ordering. Surface stale-state and coexistence warnings, and reject unsupported scope glob syntax instead of guessing.
 </must_do>
 
 <command_phase_rules>

--- a/plugins/grace/skills/grace/grace-plan/references/change-plan-template.xml
+++ b/plugins/grace/skills/grace/grace-plan/references/change-plan-template.xml
@@ -30,6 +30,8 @@
     <ImplementationPlan>
       <T-001>
         <Title>$TASK_TITLE</Title>
+        <!-- Zero or more predecessors, comma-separated: T-001, T-002. List only true
+             dependencies — never linearize independent tasks into a chain. -->
         <DependsOn></DependsOn>
         <AcceptanceCriteria>
           <Criterion>$TASK_ACCEPTANCE</Criterion>

--- a/skills/grace/grace-plan/SKILL.md
+++ b/skills/grace/grace-plan/SKILL.md
@@ -26,7 +26,7 @@ description: Read an approved GRACE 4 GraceChangeSpec and optional design contex
 </approved_plan_immutability>
 
 <must_do>
-Produce `plan.xml` from `references/change-plan-template.xml` as draft unless the user explicitly approves the completed plan. Require a matching `C-*` wrapper, meaningful intent, non-empty machine-checkable baseline and target assertions, explicit durable and observed scopes, and unique acyclic `T-NNN` tasks. A scope with no writes must use an explicit `<None />` marker; prose such as "none" is invalid. Every task has one `Title`, one `DependsOn`, non-empty acceptance criteria, and non-empty verification commands. Surface stale-state and coexistence warnings, and reject unsupported scope glob syntax instead of guessing.
+Produce `plan.xml` from `references/change-plan-template.xml` as draft unless the user explicitly approves the completed plan. Require a matching `C-*` wrapper, meaningful intent, non-empty machine-checkable baseline and target assertions, explicit durable and observed scopes, and unique acyclic `T-NNN` tasks. A scope with no writes must use an explicit `<None />` marker; prose such as "none" is invalid. Every task has one `Title`, one `DependsOn` element listing zero or more predecessors as canonical comma-separated `T-NNN` values (for example `<DependsOn>T-001, T-002</DependsOn>`), non-empty acceptance criteria, and non-empty verification commands. Dependencies form a directed acyclic graph: list only true predecessors and never linearize independent tasks into a chain to express ordering. Surface stale-state and coexistence warnings, and reject unsupported scope glob syntax instead of guessing.
 </must_do>
 
 <command_phase_rules>

--- a/skills/grace/grace-plan/references/change-plan-template.xml
+++ b/skills/grace/grace-plan/references/change-plan-template.xml
@@ -30,6 +30,8 @@
     <ImplementationPlan>
       <T-001>
         <Title>$TASK_TITLE</Title>
+        <!-- Zero or more predecessors, comma-separated: T-001, T-002. List only true
+             dependencies — never linearize independent tasks into a chain. -->
         <DependsOn></DependsOn>
         <AcceptanceCriteria>
           <Criterion>$TASK_ACCEPTANCE</Criterion>

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -11,7 +11,7 @@ import { verificationCommand } from "./grace-verification";
 const main = defineCommand({
   meta: {
     name: "grace",
-    version: "4.0.6",
+    version: "4.0.7",
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {

--- a/src/grace4/grammar.test.ts
+++ b/src/grace4/grammar.test.ts
@@ -281,6 +281,61 @@ describe("GRACE 4 Artifact Grammar", () => {
     expect(validateChangeArtifact(parseGraceXmlArtifact("plan.xml", plan), "active").issues).toHaveLength(0);
   });
 
+  it("accepts multiple predecessors in comma, space, child-tag, and legacy child-text forms", () => {
+    const forms = [
+      "T-001, T-002",
+      "T-001 T-002",
+      "<T-001 /><T-002 />",
+      "<Task>T-001</Task><Task>T-002</Task>",
+    ];
+    for (const form of forms) {
+      const plan = validPlan(
+        task("T-001") + task("T-002") + task("T-003", form),
+      );
+      const result = validateChangeArtifact(parseGraceXmlArtifact("plan.xml", plan), "active");
+      expect(result.issues, `form accepted: ${form}`).toHaveLength(0);
+    }
+  });
+
+  it("validates multi-form dependencies: unknown ids, duplicates, self, and cycles", () => {
+    const plan = validPlan([
+      task("T-001"),
+      task("T-002", "T-001, T-999"),
+      task("T-003", "T-002, T-002"),
+      task("T-004", "T-004, T-001"),
+      task("T-005", "T-006"),
+      task("T-006", "T-005"),
+    ].join(""));
+    const result = validateChangeArtifact(parseGraceXmlArtifact("plan.xml", plan), "active");
+    const resultCodes = codes(result);
+
+    expect(resultCodes).toContain("change.task-unknown-dependency");
+    expect(resultCodes).toContain("change.task-duplicate-dependency");
+    expect(resultCodes).toContain("change.task-self-dependency");
+    expect(resultCodes).toContain("change.task-dependency-cycle");
+  });
+
+  it("no longer drops unknown child-tag dependencies silently and hints the multi-dependency form", () => {
+    const plan = validPlan(task("T-001") + task("T-002", "<T-999 />"));
+    const result = validateChangeArtifact(parseGraceXmlArtifact("plan.xml", plan), "active");
+    const messages = result.issues.map((entry) => entry.message).join("\n");
+    expect(codes(result)).toContain("change.task-unknown-dependency");
+    expect(messages).toContain("T-002");
+
+    const badForm = validPlan(task("T-001") + task("T-002", "T-1 T-2"));
+    const badResult = validateChangeArtifact(parseGraceXmlArtifact("plan.xml", badForm), "active");
+    expect(badResult.issues.find((entry) => entry.code === "change.task-invalid-dependency")?.message)
+      .toContain("comma-separated");
+
+    const duplicateSection = validPlan(task("T-001") + task("T-002", "T-001").replace(
+      "<DependsOn>T-001</DependsOn>",
+      "<DependsOn>T-001</DependsOn><DependsOn>T-001</DependsOn>",
+    ));
+    const duplicateResult = validateChangeArtifact(parseGraceXmlArtifact("plan.xml", duplicateSection), "active");
+    expect(duplicateResult.issues.find((entry) => entry.code === "change.task-duplicate-section")?.message)
+      .toContain("comma-separated");
+  });
+
   it("rejects invalid active and archive change statuses", () => {
     const active = validateChangeArtifact(
       parseGraceXmlArtifact("active/plan.xml", `<GraceChangePlan graceVersion="4.0" status="applied"><C-EXAMPLE /></GraceChangePlan>`),

--- a/src/grace4/grammar.ts
+++ b/src/grace4/grammar.ts
@@ -634,7 +634,10 @@ function validateDirectSectionCardinality(
     if (matches.length === 0) {
       issues.push(issue("error", missingCode, file, `${parent.tag} is missing required direct section <${section}>.`));
     } else if (matches.length > 1) {
-      issues.push(issue("error", duplicateCode, file, `${parent.tag} contains duplicate direct <${section}> sections.`));
+      const hint = section === "DependsOn"
+        ? ` Multiple predecessors belong in ONE element, comma-separated: <DependsOn>T-001, T-002</DependsOn>.`
+        : "";
+      issues.push(issue("error", duplicateCode, file, `${parent.tag} contains duplicate direct <${section}> sections.${hint}`));
     }
   }
 }
@@ -776,15 +779,33 @@ function validatePlanTask(file: string, task: GraceXmlNode, issues: Grace4Issue[
     return [];
   }
 
+  // Multiple predecessors are allowed. Accepted forms, all equivalent:
+  //   <DependsOn>T-001, T-002</DependsOn>            comma/space-separated text (canonical)
+  //   <DependsOn>T-001 T-002</DependsOn>              space-separated text
+  //   <DependsOn><T-001 /><T-002 /></DependsOn>       child anchor tags
+  //   <DependsOn><Task>T-001</Task></DependsOn>       legacy child text
   const dependencyValues = [
-    ...(dependsOn.text.trim() ? [dependsOn.text.trim()] : []),
-    ...dependsOn.children.map((child) => child.text.trim()).filter(Boolean),
-  ];
+    ...dependsOn.text.split(/[,\s]+/),
+    ...dependsOn.children
+      .filter((child) => ANCHOR_PATTERNS.task.test(child.tag))
+      .map((child) => child.tag),
+    ...dependsOn.children
+      .filter((child) => !ANCHOR_PATTERNS.task.test(child.tag))
+      .flatMap((child) => child.text.split(/[,\s]+/)),
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
   const dependencies: string[] = [];
   const seen = new Set<string>();
   for (const dependency of dependencyValues) {
     if (!ANCHOR_PATTERNS.task.test(dependency)) {
-      issues.push(issue("error", "change.task-invalid-dependency", file, `${task.tag} dependency '${dependency}' must be a canonical T-NNN identifier.`));
+      issues.push(issue(
+        "error",
+        "change.task-invalid-dependency",
+        file,
+        `${task.tag} dependency '${dependency}' must be a canonical T-NNN identifier. ` +
+          `List multiple predecessors comma-separated in one element: <DependsOn>T-001, T-002</DependsOn>.`,
+      ));
       continue;
     }
     if (seen.has(dependency)) {


### PR DESCRIPTION
Prepare @osovv/grace-cli 4.0.7 for stable publication. After required checks pass and the pull request is merged, run `bun run release:finalize 4.0.7` from clean synchronized main to create and push the immutable release tag.