### PR TITLE
feat(lint): govern C, C++, C#, and PowerShell sources structurally

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,12 @@ Built-in ignored directories:
 - JVM and Rust build output: `target`, `.gradle`, `.idea`
 - Vendored dependencies (Go modules, Ruby bundler, PHP Composer): `vendor`
 - Swift/Apple toolchain output and dependencies: `.build`, `Pods`, `Carthage`, `DerivedData`
+- .NET intermediate build output: `obj`
 - Dart/Flutter tooling cache: `.dart_tool`
 - Ruby/general scratch space: `tmp`, `.bundle`
 - Editor metadata: `.vscode`
+
+`bin` is deliberately not built in: .NET puts compiled output there, but Node, Rails and others keep real source in it, and `ignoredDirs` can only add to this set. A .NET project that wants it pruned adds `"ignoredDirs": ["bin"]`.
 
 ### Analysis Cache
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Verification commands run from the project root by default. A `V-M-*` entry may 
 
 TypeScript/JavaScript semantic analysis is bundled and compiler-backed. Governed Python and Dart files require their respective runtimes on `PATH`; Python export analysis is exact when a static `__all__` is present (including Unicode identifiers) and otherwise emits heuristic confidence. A missing runtime fails closed with actionable `analysis.runtime-missing`; an installed adapter that fails emits `analysis.adapter-failed`. Neither failure state is presented as exact `MODULE_MAP` parity.
 
+Languages without a registered adapter — including Go, Rust, Java, shell, C/C++, C#, and PowerShell — are governed structurally: markup validity, contract completeness, and `MODULE_MAP` shape are enforced, while export parity is not analyzed. `MODULE_MAP` for these languages is taken on trust. Governance is opt-in per file; sources without GRACE markers are never flagged.
+
+Markers are recognized behind the `//`, `#`, `--`, `;` and block-comment `*` prefixes, so a language whose comments use none of those — XML-comment dialects such as `.xaml` or `.csproj` — cannot carry them.
+
 ## Install
 
 Install **skills** first. The CLI is optional but recommended once skills are installed.

--- a/src/grace-lint.test.ts
+++ b/src/grace-lint.test.ts
@@ -111,6 +111,80 @@ describe("lintGraceProject", () => {
     expect(result.xmlFilesChecked).toBeGreaterThan(0);
   });
 
+  it("counts adapter-less C sources among governed files", async () => {
+    const root = createProject();
+    writeMinimalGrace4Project(root);
+    writeProjectFile(
+      root,
+      "src/driver.c",
+      `// START_MODULE_CONTRACT
+//   PURPOSE: Bring up the example driver.
+//   SCOPE: C fixture without a language adapter.
+//   DEPENDS: none
+//   LINKS: M-EXAMPLE
+//   MAP_MODE: SUMMARY
+// END_MODULE_CONTRACT
+// START_MODULE_MAP
+//   driver_init - Initialize the driver.
+// END_MODULE_MAP
+void driver_init(void) {}
+`,
+    );
+    const result = await lintGraceProject(root);
+
+    expect(result.summary.errors).toBe(0);
+    expect(result.governedFiles).toBe(2);
+  });
+
+  it("counts adapter-less C# and PowerShell sources among governed files", async () => {
+    const root = createProject();
+    writeMinimalGrace4Project(root);
+    writeProjectFile(
+      root,
+      "src/SessionStore.cs",
+      `// START_MODULE_CONTRACT
+//   PURPOSE: Persist operator sessions.
+//   SCOPE: C# fixture without a language adapter.
+//   DEPENDS: none
+//   LINKS: M-EXAMPLE
+//   MAP_MODE: SUMMARY
+// END_MODULE_CONTRACT
+// START_MODULE_MAP
+//   SessionStore - Store and retrieve sessions.
+// END_MODULE_MAP
+namespace Example;
+
+public sealed class SessionStore
+{
+    public void Clear() { }
+}
+`,
+    );
+    writeProjectFile(
+      root,
+      "scripts/Publish.ps1",
+      `# START_MODULE_CONTRACT
+#   PURPOSE: Publish the release artifacts.
+#   SCOPE: PowerShell fixture without a language adapter.
+#   DEPENDS: none
+#   LINKS: M-EXAMPLE
+#   ROLE: SCRIPT
+#   MAP_MODE: LOCALS
+# END_MODULE_CONTRACT
+# START_MODULE_MAP
+#   Publish-Artifacts - Copy artifacts to the release share.
+# END_MODULE_MAP
+function Publish-Artifacts {
+  Write-Output 'published'
+}
+`,
+    );
+    const result = await lintGraceProject(root);
+
+    expect(result.summary.errors).toBe(0);
+    expect(result.governedFiles).toBe(3);
+  });
+
   it("fails with migration guidance when only GRACE 3 docs are present", async () => {
     const root = createProject();
     writeProjectFile(root, "docs/development-plan.xml", `<DevelopmentPlan />`);

--- a/src/language-registry.ts
+++ b/src/language-registry.ts
@@ -10,6 +10,8 @@ import type { LanguageAdapter } from "./lint/types";
 export const CODE_EXTENSIONS: ReadonlySet<string> = new Set([
   ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts",
   ".py", ".pyi",
+  ".c", ".h", ".cpp", ".hpp",
+  ".cs",
   ".go",
   ".java",
   ".kt",
@@ -20,6 +22,7 @@ export const CODE_EXTENSIONS: ReadonlySet<string> = new Set([
   ".scala",
   ".sql",
   ".sh", ".bash", ".zsh",
+  ".ps1", ".psm1",
   ".clj", ".cljs", ".cljc",
   ".dart",
 ]);

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -314,6 +314,118 @@ console.log(JSON.stringify(result.issues));`;
     expect(issues.map((issue) => issue.code)).toContain("analysis.adapter-failed");
     expect(issues.map((issue) => issue.code)).not.toContain("analysis.runtime-missing");
   });
+
+  it("governs adapter-less C sources structurally without export analysis", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-c-markup-"));
+    const file = path.join(root, "src", "driver.c");
+    const text = `// START_MODULE_CONTRACT
+// PURPOSE: Bring up the example driver.
+// SCOPE: C fixture without a language adapter.
+// DEPENDS: none
+// LINKS: M-EXAMPLE
+// MAP_MODE: SUMMARY
+// END_MODULE_CONTRACT
+// START_MODULE_MAP
+// driver_init - Initialize the driver.
+// END_MODULE_MAP
+#include <stdint.h>
+void driver_init(void) {}
+`;
+    const analysis = analyzeGovernedFile(root, file, text);
+    expect(analysis.record.linkedModuleIds).toEqual(["M-EXAMPLE"]);
+    expect(analysis.language).toBeNull();
+    expect(analysis.issues.filter((issue) => issue.severity === "error")).toHaveLength(0);
+    expect(analysis.issues.map((issue) => issue.code)).not.toContain("analysis.heuristic-confidence");
+  });
+
+  it("parses C block-comment markers with asterisk continuation lines", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-h-markup-"));
+    const file = path.join(root, "src", "driver.h");
+    const text = `/*
+ * START_MODULE_CONTRACT
+ * PURPOSE: Declare the example driver API.
+ * SCOPE: C header fixture.
+ * DEPENDS: none
+ * LINKS: M-EXAMPLE
+ * MAP_MODE: SUMMARY
+ * END_MODULE_CONTRACT
+ * START_MODULE_MAP
+ * driver_init - Initialize the driver.
+ * END_MODULE_MAP
+ */
+void driver_init(void);
+`;
+    const analysis = analyzeGovernedFile(root, file, text);
+    expect(analysis.record.moduleContract?.fields.PURPOSE).toBe("Declare the example driver API.");
+    expect(analysis.language).toBeNull();
+    expect(analysis.issues.filter((issue) => issue.severity === "error")).toHaveLength(0);
+  });
+
+  it("governs adapter-less C# sources structurally without export analysis", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-cs-markup-"));
+    const file = path.join(root, "src", "SessionStore.cs");
+    const text = `// START_MODULE_CONTRACT
+// PURPOSE: Persist operator sessions.
+// SCOPE: C# fixture without a language adapter.
+// DEPENDS: none
+// LINKS: M-EXAMPLE
+// MAP_MODE: SUMMARY
+// END_MODULE_CONTRACT
+// START_MODULE_MAP
+// SessionStore - Store and retrieve sessions.
+// END_MODULE_MAP
+namespace Example;
+
+public sealed class SessionStore
+{
+    public void Clear() { }
+}
+`;
+    const analysis = analyzeGovernedFile(root, file, text);
+    expect(analysis.record.linkedModuleIds).toEqual(["M-EXAMPLE"]);
+    expect(analysis.language).toBeNull();
+    expect(analysis.issues.filter((issue) => issue.severity === "error")).toHaveLength(0);
+    expect(analysis.issues.map((issue) => issue.code)).not.toContain("analysis.heuristic-confidence");
+  });
+
+  it("parses PowerShell markers behind the hash comment prefix", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-ps1-markup-"));
+    const file = path.join(root, "scripts", "Publish.ps1");
+    const text = `# START_MODULE_CONTRACT
+# PURPOSE: Publish the release artifacts.
+# SCOPE: PowerShell fixture without a language adapter.
+# DEPENDS: none
+# LINKS: M-EXAMPLE
+# ROLE: SCRIPT
+# MAP_MODE: LOCALS
+# END_MODULE_CONTRACT
+# START_MODULE_MAP
+# Publish-Artifacts - Copy artifacts to the release share.
+# END_MODULE_MAP
+function Publish-Artifacts {
+  Write-Output 'published'
+}
+`;
+    const analysis = analyzeGovernedFile(root, file, text);
+    expect(analysis.record.moduleContract?.fields.PURPOSE).toBe("Publish the release artifacts.");
+    expect(analysis.record.linkedModuleIds).toEqual(["M-EXAMPLE"]);
+    expect(analysis.language).toBeNull();
+    expect(analysis.issues.filter((issue) => issue.severity === "error")).toHaveLength(0);
+  });
+});
+
+describe("code file collection", () => {
+  it("collects newly recognized sources while skipping unrecognized extensions", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-collect-"));
+    mkdirSync(path.join(root, "src"), { recursive: true });
+    for (const relative of ["src/main.c", "src/main.h", "src/util.cpp", "src/util.hpp", "src/Store.cs", "src/Build.ps1", "src/Helpers.psm1", "src/Module.psd1", "src/notes.txt", "README.md"]) {
+      writeFileSync(path.join(root, relative), "\n");
+    }
+
+    const collected = collectCodeFiles(root, []).map((file) => path.relative(root, file).replaceAll(path.sep, "/")).sort();
+
+    expect(collected).toEqual(["src/Build.ps1", "src/Helpers.psm1", "src/Store.cs", "src/main.c", "src/main.h", "src/util.cpp", "src/util.hpp"]);
+  });
 });
 
 describe("unreadable directory walking", () => {

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -426,6 +426,20 @@ describe("code file collection", () => {
 
     expect(collected).toEqual(["src/Build.ps1", "src/Helpers.psm1", "src/Store.cs", "src/main.c", "src/main.h", "src/util.cpp", "src/util.hpp"]);
   });
+
+  it("prunes .NET intermediate output while leaving bin to project configuration", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "grace-dotnet-collect-"));
+    for (const relative of ["src/Store.cs", "src/obj/Debug/Store.AssemblyInfo.cs", "src/bin/Debug/Tool.cs"]) {
+      mkdirSync(path.join(root, path.dirname(relative)), { recursive: true });
+      writeFileSync(path.join(root, relative), "\n");
+    }
+
+    const withDefaults = collectCodeFiles(root, []).map((file) => path.relative(root, file).replaceAll(path.sep, "/")).sort();
+    expect(withDefaults).toEqual(["src/Store.cs", "src/bin/Debug/Tool.cs"]);
+
+    const withBinIgnored = collectCodeFiles(root, ["bin"]).map((file) => path.relative(root, file).replaceAll(path.sep, "/"));
+    expect(withBinIgnored).toEqual(["src/Store.cs"]);
+  });
 });
 
 describe("unreadable directory walking", () => {

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -126,6 +126,8 @@ const DEFAULT_IGNORED_DIRS = new Set([
   "Pods",
   "Carthage",
   "DerivedData",
+  // .NET intermediate build output, which holds generated .cs sources
+  "obj",
   // Dart/Flutter tooling cache
   ".dart_tool",
   // Ruby/general scratch space and bundler config


### PR DESCRIPTION
## Summary

Adds `.c` / `.h` / `.cpp` / `.hpp`, `.cs`, and `.ps1` / `.psm1` to `CODE_EXTENSIONS` so those languages can opt into GRACE governance the same way Go, Rust, Java, shell, and the other adapter-less languages already do. A second commit adds `obj` to the built-in ignored directories, which the first commit makes necessary.

## Motivation

`src/language-registry.ts` has two tiers. `CODE_EXTENSIONS` is the set the linter collects and governs — markup validity, `MODULE_CONTRACT` completeness, `ROLE`/`MAP_MODE` shape, and `grace file show` navigation. `ADAPTER_BACKED_EXTENSIONS` is the smaller subset that additionally gets export-parity analysis. Go, Rust, Java and shell live in the first tier with no adapter and are fully governable.

C, C++, C# and PowerShell are in neither tier. A file whose extension is absent is never collected by the walk (`src/project-utils.ts`, `collectCodeFiles`), so its GRACE markup is neither validated nor navigable — and, because collection happens before any check, nothing reports the omission. A `MODULE_CONTRACT` header in a `.cs` file is simply invisible.

This puts all four in the first tier only. No adapter, parser, or analysis change is needed:

- C-family and C# use `//` line comments, already handled by `stripCommentPrefix`, as is block-comment `*` continuation for headers.
- PowerShell uses `#`, the same prefix Python and shell already rely on.
- `inferRole` is path-based rather than extension-based, so the new languages classify exactly as the existing adapter-less ones do.

Export parity for these languages is explicitly out of scope; `MODULE_MAP` is taken on trust until an adapter exists. For C# specifically, 4.0.5 already credits log-marker emissions from non-JS loggers as verification evidence (#30), so this registry change completes the structural half of the story.

This is the same gap #28 closed for Dart, minus the adapter half.

## The `obj` commit, and why `bin` is not in it

Once `.cs` is collectible, a walk of any .NET repository descends into `obj/`, which holds generated sources — `AssemblyInfo`, `GlobalUsings`, NuGet shims — that no author governs. The built-in ignored set has no .NET entry, so the first commit alone would regress every .NET user. `obj` joins the list beside the existing per-ecosystem groups.

`bin` is deliberately left out. .NET puts compiled output there, but Node, Rails and others keep real source in `bin/`, and `ignoredDirs` can only *add* to the built-in set — there is no way to subtract from it. A built-in `bin` would therefore silently stop governing those projects with no opt-out, which is the exact failure this PR exists to fix. A .NET project that wants it pruned adds `"ignoredDirs": ["bin"]`, and the README now says so where the built-in list is documented.

## Backwards safety

Governance is opt-in per file: `hasGraceMarkers` skips sources carrying no GRACE markers, so an existing project sees a higher `Files checked` count and nothing else.

Measured on a project holding one governed `.ts` module plus four unmarked C-family sources, two unmarked `.cs` files, two generated `.cs` under `obj/`, one `.cs` under `bin/`, a `.ps1`, a `.psm1`, and a `.psd1`:

| | `main` (`196faa6`) | this branch |
|---|---|---|
| Files checked | 2 | **11** |
| Governed files | 1 | 1 |
| Errors | 0 | 0 |
| Warnings | 0 | 0 |
| Exit code | 0 | 0 |

Eleven rather than thirteen: the two generated sources under `obj/` are pruned, and `.psd1` is not a recognized extension. The one under `bin/` is still walked, as documented.

## Tests

- `project-utils.test.ts` — structural governance with `language: null` and no errors for `.c` (line comments) and `.cs`; `.h` block-comment markers with `*` continuation lines; `.ps1` markers behind the `#` prefix with `ROLE: SCRIPT` / `MAP_MODE: LOCALS`; a `collectCodeFiles` membership test covering all seven new extensions and proving `.psd1`, `.txt` and `.md` stay out; and a `.NET` walk test asserting `obj/` is pruned by default while `bin/` is reachable and prunable through `ignoredDirs`.
- `grace-lint.test.ts` — a project with a governed `.c` file reports `governedFiles: 2`; a project with a governed `.cs` and a governed `.ps1` reports `governedFiles: 3`. Both with zero errors through `lintGraceProject`.

## Verification

Windows 11, bun 1.3.14:

| | `main` (`196faa6`) | this branch |
|---|---|---|
| `bun run typecheck` | clean | clean |
| `bun run test` | 347 pass / 8 skip / 15 fail | **355 pass** / 8 skip / 15 fail |
| `bun run validate:cli` | 66 pass / 1 skip / 0 fail | **68 pass** / 1 skip / 0 fail |
| `bun run validate:marketplace` | pass | pass |

The eight new tests pass; the failing set is identical on both, so this branch introduces no failure. Those fifteen are pre-existing Windows fixture-portability failures — POSIX-only `printf`, `true`/`false` and `#!/bin/sh` shims, and `symlinkSync` EPERM without Developer Mode — unrelated to this change and unreachable by the `windows-compatibility` CI job, which today runs four files rather than the suite. #41 fixes all fifteen and turns that job green.

lefthook pre-commit (typecheck, validate-marketplace) and commitlint pass.

## Known limitations, recorded rather than solved

- **XML-comment languages cannot carry markers.** The grammar recognizes `//`, `#`, `--`, `;` and block-comment `*` prefixes only, so `.xaml`, `.axaml` and `.csproj` are out of reach. No grammar work is proposed here; the README now states the constraint where the tier is described.
- **C# test files infer `RUNTIME`.** `inferRole` matches a `tests/` path segment or a `.test.`/`.spec.` suffix, neither of which fits the `Foo.Tests/FooTests.cs` convention. Authors set `ROLE: TEST` explicitly. Widening role inference is a separate design call.

## Docs

The README's structural-governance paragraph now names C#, PowerShell and the C family, states that `MODULE_MAP` for the tier is taken on trust, and records the comment-prefix constraint. The built-in ignored-directory list gains `obj` and the note on `bin`.
