### PR TITLE
chore: prepare 4.1.0 stable release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "GRACE (Graph-RAG Anchored Code Engineering) - a methodology by Vladimir Ivanov for contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification",
-    "version": "4.0.7"
+    "version": "4.1.0"
   },
   "plugins": [
     {
       "name": "grace",
       "source": "./plugins/grace",
       "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-      "version": "4.0.7",
+      "version": "4.1.0",
       "author": {
         "name": "osovv",
         "url": "https://github.com/osovv"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## <small>4.1.0 (2026-09-03)</small>
+
+### Summary
+
+Users working with .NET, C/C++, or PowerShell codebases gain meaningful lint coverage in 4.1.0: C, C++, C#, and PowerShell source files can now opt into structural governance—markup validity, contract completeness, and MODULE_MAP shape are enforced the same way they already are for Go, Rust, Java, and shell—while the default ignored-directory set now prunes .NET's `obj` intermediate output, where generated sources no author edits would otherwise be walked and analyzed. Windows users and CI see several reliability fixes: forwarded command output no longer carries a trailing carriage return that corrupted live logs and terminal rendering, command-runner test fixtures were made shell-portable so the suite reports real results on cmd.exe instead of false failures, and the Windows CI job now runs the full test suite rather than a handful of files, with POSIX-only symlink, permission, and shell fixtures skipped cleanly on that platform.
+
+* feat(cli): ignore .NET intermediate build output ([2bd4485](https://github.com/osovv/grace-marketplace/commit/2bd4485))
+* feat(lint): govern C, C++, C#, and PowerShell sources structurally ([8bcac9b](https://github.com/osovv/grace-marketplace/commit/8bcac9b))
+* test(windows): make command-runner fixtures shell-portable ([1e2f1b8](https://github.com/osovv/grace-marketplace/commit/1e2f1b8))
+* test(windows): skip POSIX-only fixtures and widen the Windows CI job ([0815521](https://github.com/osovv/grace-marketplace/commit/0815521))
+* fix(lint): strip the carriage return from forwarded command output ([fc08a21](https://github.com/osovv/grace-marketplace/commit/fc08a21))
+
 ## <small>4.0.7 (2026-08-29)</small>
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository ships the GRACE skills plus the optional `grace` CLI. It is a packaging and distribution repository, not an end-user application.
 
-Current packaged version: `4.0.7`
+Current packaged version: `4.1.0`
 
 ## What This Repository Ships
 

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,6 +1,6 @@
 name: grace
 description: "GRACE (Graph-RAG Anchored Code Engineering) - contract-first AI engineering with semantic markup, knowledge graphs, and log-driven verification"
-version: 4.0.7
+version: 4.1.0
 author: osovv
 license: MIT
 keywords:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osovv/grace-cli",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "description": "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation with a Bun-powered grace binary.",
   "license": "MIT",
   "homepage": "https://github.com/osovv/grace-marketplace#readme",

--- a/plugins/grace/.claude-plugin/plugin.json
+++ b/plugins/grace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grace",
   "description": "Complete GRACE methodology: semantic markup, knowledge graphs, module contracts, testing, and log-driven verification for AI-driven engineering",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "author": {
     "name": "osovv",
     "url": "https://github.com/osovv"

--- a/src/grace.ts
+++ b/src/grace.ts
@@ -11,7 +11,7 @@ import { verificationCommand } from "./grace-verification";
 const main = defineCommand({
   meta: {
     name: "grace",
-    version: "4.0.7",
+    version: "4.1.0",
     description: "GRACE 4 CLI for .grace linting, status snapshots, module health, verification queries, semantic markup, and artifact navigation.",
   },
   subCommands: {


### PR DESCRIPTION
Prepare @osovv/grace-cli 4.1.0 for stable publication. After required checks pass and the pull request is merged, run `bun run release:finalize 4.1.0` from clean synchronized main to create and push the immutable release tag.