### PR TITLE
fix(lint): credit Go's stdlib logger, and stop crediting error construction

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/sethosher/projects/personal/grace-marketplace/node_modules

--- a/src/project-utils.test.ts
+++ b/src/project-utils.test.ts
@@ -112,6 +112,33 @@ export const value = true;
     expect(hasRuntimeMarkerEvidence(`// const marker$ = "${marker}";\nconsole.info(marker$ + " ok");`, marker)).toBe(false);
   });
 
+  it("credits Go's standard-library logger, which has no levelled methods", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    // The `log` package is Go's DEFAULT logging API and its only methods are the
+    // Print/Fatal/Panic families. A module using it emitted the marker just as
+    // surely as one using slog, and used to earn no credit at all for doing so.
+    expect(hasRuntimeMarkerEvidence(`log.Printf("${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`log.Println("${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`log.Print("${marker} ok")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`log.Fatalf("${marker} died: %v", err)`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`log.Panicln("${marker} died")`, marker)).toBe(true);
+    // fmt is not a logger, but a marker printed through it is still emitted.
+    expect(hasRuntimeMarkerEvidence(`fmt.Printf("${marker} ok\\n")`, marker)).toBe(true);
+    expect(hasRuntimeMarkerEvidence(`fmt.Fprintln(os.Stderr, "${marker} ok")`, marker)).toBe(true);
+  });
+
+  it("does not credit an argument-less call, so err.Error() is not an emission", () => {
+    const marker = "[Example][run][BLOCK_RUN]";
+    // NEGATIVE CONTROL. `err.Error()` is Go's error-string method and appears on
+    // countless non-logging lines. Credited, it lets a module that merely
+    // MENTIONS its marker beside a wrapped error pass the required-marker gate
+    // without ever having emitted anything.
+    expect(hasRuntimeMarkerEvidence(`return fmt.Errorf("${marker} %s", err.Error())`, marker)).toBe(false);
+    expect(hasRuntimeMarkerEvidence(`x := "${marker}" + err.Error()`, marker)).toBe(false);
+    // The same line with a real emission still counts, so the guard stays narrow.
+    expect(hasRuntimeMarkerEvidence(`logger.Error("${marker} " + err.Error())`, marker)).toBe(true);
+  });
+
   it("credits capitalised logger methods used by Go, Java, and C#", () => {
     const marker = "[Example][run][BLOCK_RUN]";
     // Go stdlib log

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -215,11 +215,11 @@ function isCommentOnlyLine(line: string) {
  * ILogger's (`LogWarning`, `LogInformation`). Without them those two only match
  * when the receiver happens to be called `logger`, which is not a guarantee.
  *
- * `print`/`fprint`/`fatal`/`panic` are Go's STANDARD LIBRARY logger, which has
- * no levelled methods at all - `log.Printf`, `log.Println`, `log.Fatal`. A Go
- * module emitting its required marker through the language's own default
- * logging API earned no credit before this, so the most idiomatic spelling
- * tripped the very blocker this function exists to prevent.
+ * `print`/`fatal`/`panic` cover Go's standard-library `log` package, which has
+ * no levelled methods at all - `log.Printf`, `log.Println`, `log.Fatal`. `fprint`
+ * covers `fmt.Fprint*`, which isn't logging but still emits to stdout/stderr.
+ * A Go module emitting its required marker through these standard APIs earned no
+ * credit before this, so the most idiomatic spelling tripped the blocker.
  *
  * Go's error CONSTRUCTION spellings are removed before the test rather than
  * excluded inside it. `fmt.Errorf` matches `.error` + the `f` suffix, and

--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -214,10 +214,28 @@ function isCommentOnlyLine(line: string) {
  * `severe` is java.util.logging's error level, and the `log*` names are C#
  * ILogger's (`LogWarning`, `LogInformation`). Without them those two only match
  * when the receiver happens to be called `logger`, which is not a guarantee.
+ *
+ * `print`/`fprint`/`fatal`/`panic` are Go's STANDARD LIBRARY logger, which has
+ * no levelled methods at all - `log.Printf`, `log.Println`, `log.Fatal`. A Go
+ * module emitting its required marker through the language's own default
+ * logging API earned no credit before this, so the most idiomatic spelling
+ * tripped the very blocker this function exists to prevent.
+ *
+ * Go's error CONSTRUCTION spellings are removed before the test rather than
+ * excluded inside it. `fmt.Errorf` matches `.error` + the `f` suffix, and
+ * `err.Error()` matches `.error`, so both were read as emissions - which let a
+ * line that merely MENTIONS its marker beside a wrapped error satisfy the
+ * required-marker gate without emitting anything. Stripping the named
+ * constructs keeps the emission pattern itself readable, and leaves a real
+ * emission on the same line still detectable:
+ * `logger.Error("<marker> " + err.Error())` loses only the `err.Error()`.
  */
+const NON_EMITTING_CONSTRUCTS = /\bfmt\.Errorf\s*\(|\berrors\.(?:New|Is|As|Join|Unwrap)\s*\(|\.Error\s*\(\s*\)/gi;
+
 function looksLikeEvidenceEmission(line: string) {
-  return /(console\.|logger\.|tracer\.|trace\s*\(|emit\s*\(|\.(?:info|warn(?:ing)?|error|debug|trace|severe|log(?:information|warning|error|debug|trace|critical))(?:f|w|ln)?(?:context)?\s*\()/i.test(
-    line,
+  const emitting = line.replace(NON_EMITTING_CONSTRUCTS, "");
+  return /(console\.|logger\.|tracer\.|trace\s*\(|emit\s*\(|\.(?:info|warn(?:ing)?|error|debug|trace|severe|f?print|fatal|panic|log(?:information|warning|error|debug|trace|critical))(?:f|w|ln)?(?:context)?\s*\()/i.test(
+    emitting,
   );
 }
 


### PR DESCRIPTION
Two defects in the marker-evidence check. Both were reported against downstream work on our fork, but both live here — in `looksLikeEvidenceEmission`, merged as `b9d7507` (#30).

## 1. Go's default logger earns no credit at all

The `log` package — Go's *standard library* logging API — has no levelled methods. Its whole surface is `Print`/`Fatal`/`Panic`:

```go
log.Printf("[Module][fn][BLOCK_X] started")   // credited: nothing
```

None of `info|warn|error|debug|trace|severe|log*` can match that, so a module emitting its required marker through the language's own default logger tripped an **error-severity** `health.required-log-marker-not-found` — the exact failure this function exists to prevent.

Adds the `Print`/`Fatal`/`Panic` families, and `fmt`'s `Print`/`Fprint`, which aren't logging but do emit.

## 2. Go's error *construction* is credited as an emission

`fmt.Errorf` matches `.error` plus the `f` suffix, and `err.Error()` matches `.error`. So:

```go
return fmt.Errorf("[Module][fn][BLOCK_X] failed: %s", err.Error())
```

…satisfied the required-marker gate while emitting nothing. `err.Error()` is ubiquitous in Go, so this is not a corner case — it silently converts the gate into one that passes on mention rather than emission.

### Why stripping rather than lookbehinds

The excluded constructs are removed from the line before the test, instead of being encoded as negative lookbehinds inside an already-dense pattern. The emission regex stays readable, each excluded spelling is named where a reader can see it, and a genuine emission on the same line still counts:

```go
logger.Error("[Module][fn][BLOCK_X] " + err.Error())   // still credited
```

only loses the `err.Error()` fragment.

## Verification

- **Mutation-verified, both directions.** Reverted to the old regex with the new tests in place: the stdlib-logger test and the negative control both **fail**. Restored: both **pass**. A negative control matters more than the positive one here, because the defect it pins is a check that passes when it should not.
- Suite: **343 pass / 33 fail** — and the 33 are a byte-identical failure set to unmodified `main`, measured by diffing sorted failure names rather than comparing counts.

## Provenance

Reported by automated review on `pilotso11/grace-marketplace` #6 (High) and #10 (High, re-verified at `e3f1116`), both naming the same root cause:

> Stdlib `log.Printf`/`log.Println` (and `fmt.Print*`) still count as no emission, so a Go module emitting its required marker through Go's default logger gets a false `health.required-log-marker-not-found` blocker.

> …the case-insensitive `error` alternative still credits the ubiquitous non-logging `err.Error(` as an emission.

Those PRs carry downstream Go-adapter work not offered here; this is the upstream-only half, extracted so it can land on its own.
